### PR TITLE
Add github releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Ember Data Github 
+# Ember Data Github
 
 [![Build Status](https://travis-ci.org/elwayman02/ember-data-github.svg?branch=master)](https://travis-ci.org/elwayman02/ember-data-github)
 [![Ember Observer Score](http://emberobserver.com/badges/ember-data-github.svg)](http://emberobserver.com/addons/ember-data-github)
@@ -22,6 +22,8 @@ this.get('store').findRecord('githubUser', '#'); // get the current user
 this.get('store').findRecord('githubUser', 'jimmay5469'); // get a user
 this.get('store').findRecord('githubRepository', 'jimmay5469/old-hash'); // get a repository
 this.get('store').findRecord('githubBranch, 'jimmay5469/old-hash/branches/master'); // get a branch
+this.get('store').queryRecord('githubRelease', { repo: 'jimmay5469/old-hash', releaseId: 1 }) // get a specific release
+this.get('store').query('githubRelease', { repo: 'jimmay5469/old-hash' }) // get a repo's releases
 ```
 
 ## Contributing

--- a/addon/adapters/github-release.js
+++ b/addon/adapters/github-release.js
@@ -1,0 +1,18 @@
+import GithubAdapter from './github';
+
+export default GithubAdapter.extend({
+  urlForQuery(query) {
+    const repo = query.repo;
+    delete query.repo;
+    return `${this.get('host')}/repos/${repo}/releases`;
+  },
+
+  urlForQueryRecord(query) {
+    const repo = query.repo;
+    const releaseId = query.releaseId;
+    delete query.repo;
+    delete query.releaseId;
+
+    return `${this.get('host')}/repos/${repo}/releases/${releaseId}`;
+  }
+});

--- a/addon/models/github-release.js
+++ b/addon/models/github-release.js
@@ -1,0 +1,23 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  name: DS.attr('string'),
+  url: DS.attr('string'),
+  htmlUrl: DS.attr('string'),
+  assetsUrl: DS.attr('string'),
+  uploadUrl: DS.attr('string'),
+  tarballUrl: DS.attr('string'),
+  zipballUrl: DS.attr('string'),
+  tagName: DS.attr('string'),
+  targetCommitish: DS.attr('string'),
+  body: DS.attr('string'),
+  draft: DS.attr('boolean'),
+  prerelease: DS.attr('boolean'),
+  createdAt: DS.attr('date'),
+  publishedAt: DS.attr('date'),
+
+  user: DS.belongsTo('githubUser', {
+    async: true,
+    inverse: null
+  })
+});

--- a/addon/models/github-repository.js
+++ b/addon/models/github-repository.js
@@ -20,5 +20,6 @@ export default DS.Model.extend({
     inverse: null
   }),
   branches: DS.hasMany('githubBranch', { async: true }),
-  pulls: DS.hasMany('githubPull', { async: true })
+  pulls: DS.hasMany('githubPull', { async: true }),
+  releases: DS.hasMany('githubRelease', { async: true })
 });

--- a/addon/models/github-user.js
+++ b/addon/models/github-user.js
@@ -11,5 +11,6 @@ export default DS.Model.extend({
   following: DS.attr('number'),
   createdAt: DS.attr('date'),
   updatedAt: DS.attr('date'),
+  url: DS.attr('string'),
   githubRepositories: DS.hasMany('githubRepository', { async: true })
 });

--- a/addon/serializers/github-release.js
+++ b/addon/serializers/github-release.js
@@ -1,0 +1,15 @@
+import GithubSerializer from './github';
+import { decamelize } from 'ember-string';
+
+export default GithubSerializer.extend({
+  keyForAttribute(attr) {
+    return decamelize(attr);
+  },
+
+  normalize(modelClass, resourceHash, prop) {
+    resourceHash.links = {
+      user: resourceHash.author.url
+    };
+    return this._super(modelClass, resourceHash, prop);
+  }
+});

--- a/addon/serializers/github-repository.js
+++ b/addon/serializers/github-repository.js
@@ -18,7 +18,8 @@ export default GithubSerializer.extend({
         owner: resourceHash.owner.url,
         defaultBranch: `${resourceHash.url}/branches/${resourceHash.default_branch}`,
         branches: `${resourceHash.url}/branches`,
-        pulls: `${resourceHash.url}/pulls`
+        pulls: `${resourceHash.url}/pulls`,
+        releases: `${resourceHash.url}/releases`
       }
     };
     return this._super(modelClass, hash, prop);

--- a/addon/serializers/github-user.js
+++ b/addon/serializers/github-user.js
@@ -21,6 +21,7 @@ export default GithubSerializer.extend({
       following: resourceHash.following,
       createdAt: resourceHash.created_at,
       updatedAt: resourceHash.updated_at,
+      url: resourceHash.url,
       links: {
         githubRepositories: resourceHash.repos_url
       }

--- a/app/adapters/github-release.js
+++ b/app/adapters/github-release.js
@@ -1,0 +1,3 @@
+import githubRelease from 'ember-data-github/adapters/github-release';
+
+export default githubRelease;

--- a/app/models/github-release.js
+++ b/app/models/github-release.js
@@ -1,0 +1,3 @@
+import githubRelease from 'ember-data-github/models/github-release';
+
+export default githubRelease;

--- a/app/serializers/github-release.js
+++ b/app/serializers/github-release.js
@@ -1,0 +1,3 @@
+import githubRelease from 'ember-data-github/serializers/github-release';
+
+export default githubRelease;

--- a/tests/acceptance/github-release-test.js
+++ b/tests/acceptance/github-release-test.js
@@ -1,0 +1,108 @@
+import { test } from 'qunit';
+import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
+import startApp from 'dummy/tests/helpers/start-app';
+import Pretender from 'pretender';
+import Ember from 'ember';
+
+const { run } = Ember;
+
+let server, app, container, store;
+
+moduleForAcceptance('Acceptance | github release', {
+  beforeEach() {
+    server = new Pretender();
+    server.prepareBody = function (body) {
+      return JSON.stringify(body);
+    };
+    app = startApp();
+    container = app.__container__;
+    store = run(container, 'lookup', 'service:store');
+  },
+
+  afterEach() {
+    server.shutdown();
+    run(app, app.destroy);
+    Ember.BOOTED = false;
+  }
+});
+
+test('finding a release without authorization', function (assert) {
+  assert.expect(18);
+
+  server.get('/repos/user1/repository1/releases/1', () => {
+    return [200, {}, Factory.build('release')];
+  });
+
+  return run(() => {
+    return store.queryRecord('githubRelease', { repo: 'user1/repository1', releaseId: '1' }).then((release) => {
+      assertGithubReleaseOk(assert, release);
+      assert.equal(store.peekAll('githubRelease').get('length'), 1, 'loads 1 release');
+      assert.equal(server.handledRequests.length, 1, 'handles 1 request');
+      assert.equal(server.handledRequests[0].requestHeaders.Authorization, undefined, 'has no authorization token');
+    });
+  });
+});
+
+test('finding a release', function (assert) {
+  assert.expect(18);
+
+  container.lookup('service:github-session').set('githubAccessToken', 'abc123');
+  server.get('/repos/user1/repository1/releases/1', () => {
+    return [200, {}, Factory.build('release')];
+  });
+
+  return run(() => {
+    return store.queryRecord('githubRelease', { repo: 'user1/repository1', releaseId: '1' }).then((release) => {
+      assertGithubReleaseOk(assert, release);
+      assert.equal(store.peekAll('githubRelease').get('length'), 1, 'loads 1 release');
+      assert.equal(server.handledRequests.length, 1, 'handles 1 request');
+      assert.equal(server.handledRequests[0].requestHeaders.Authorization, 'token abc123', 'has the authorization token');
+    });
+  });
+});
+
+test('finding all releases', function (assert) {
+  assert.expect(18);
+
+  container.lookup('service:github-session').set('githubAccessToken', 'abc123');
+  server.get('/repos/user1/repository1/releases', () => {
+    return [200, {},
+      [
+        Factory.build('release'),
+        Factory.build('release')
+      ]
+    ];
+  });
+
+  return run(() => {
+    return store.query('githubRelease', { repo: 'user1/repository1' }).then((releases) => {
+      assertGithubReleaseOk(assert, releases.toArray()[0]);
+      assert.equal(store.peekAll('githubRelease').get('length'), 2, 'loads 2 releases');
+      assert.equal(server.handledRequests.length, 1, 'handles 1 request');
+      assert.equal(server.handledRequests[0].requestHeaders.Authorization, 'token abc123', 'has the authorization token');
+    });
+  });
+});
+
+test('getting a releases\' author', function (assert) {
+  assert.expect(15);
+
+  container.lookup('service:github-session').set('githubAccessToken', 'abc123');
+  server.get('/repos/user1/repository1/releases/1', () => {
+    return [200, {}, Factory.build('release')];
+  });
+  server.get('/users/user1', () => {
+    return [200, {}, Factory.build('user')];
+  });
+
+  return run(() => {
+    return store.queryRecord('githubRelease', { repo: 'user1/repository1', releaseId: '1' }).then((release) => {
+      return release.get('user').then(function (user) {
+        assertGithubUserOk(assert, user);
+        assert.equal(store.peekAll('githubUser').get('length'), 1, 'loads 1 user');
+        assert.equal(server.handledRequests.length, 2, 'handles 2 requests');
+        assert.equal(server.handledRequests[0].requestHeaders.Authorization, 'token abc123', 'has the authorization token');
+      });
+    });
+  });
+});

--- a/tests/acceptance/github-repository-test.js
+++ b/tests/acceptance/github-repository-test.js
@@ -27,6 +27,8 @@ moduleForAcceptance('Acceptance | github repository', {
 });
 
 test('finding a repository without authorization', function (assert) {
+  assert.expect(12);
+
   server.get('/repos/User1/Repository1', () => {
     return [200, {}, Factory.build('repository')];
   });
@@ -34,14 +36,16 @@ test('finding a repository without authorization', function (assert) {
   return run(() => {
     return store.findRecord('githubRepository', 'User1/Repository1').then((repository) => {
       assertGithubRepositoryOk(assert, repository);
-      assert.equal(store.peekAll('githubRepository').get('length'), 1);
-      assert.equal(server.handledRequests.length, 1);
-      assert.equal(server.handledRequests[0].requestHeaders.Authorization, undefined);
+      assert.equal(store.peekAll('githubRepository').get('length'), 1, 'loads 1 repository');
+      assert.equal(server.handledRequests.length, 1, 'handles 1 request');
+      assert.equal(server.handledRequests[0].requestHeaders.Authorization, undefined, 'has no authorization token');
     });
   });
 });
 
 test('finding a repository', function (assert) {
+  assert.expect(12);
+
   container.lookup('service:github-session').set('githubAccessToken', 'abc123');
   server.get('/repos/user1/repository1', () => {
     return [200, {}, Factory.build('repository')];
@@ -50,14 +54,16 @@ test('finding a repository', function (assert) {
   return run(() => {
     return store.findRecord('githubRepository', 'user1/repository1').then((repository) => {
       assertGithubRepositoryOk(assert, repository);
-      assert.equal(store.peekAll('githubRepository').get('length'), 1);
-      assert.equal(server.handledRequests.length, 1);
-      assert.equal(server.handledRequests[0].requestHeaders.Authorization, 'token abc123');
+      assert.equal(store.peekAll('githubRepository').get('length'), 1), 'loads 1 repository';
+      assert.equal(server.handledRequests.length, 1, 'handles 1 request');
+      assert.equal(server.handledRequests[0].requestHeaders.Authorization, 'token abc123', 'has the authorization token');
     });
   });
 });
 
 test('finding all repositories', function (assert) {
+  assert.expect(12);
+
   container.lookup('service:github-session').set('githubAccessToken', 'abc123');
   server.get('/repositories', () => {
     let response = [
@@ -69,15 +75,17 @@ test('finding all repositories', function (assert) {
 
   return run(() => {
     return store.findAll('githubRepository').then(function (repositories) {
-      assert.equal(repositories.get('length'), 2);
+      assert.equal(repositories.get('length'), 2, 'loads 2 repositories');
       assertGithubRepositoryOk(assert, repositories.toArray()[0]);
-      assert.equal(server.handledRequests.length, 1);
-      assert.equal(server.handledRequests[0].requestHeaders.Authorization, 'token abc123');
+      assert.equal(server.handledRequests.length, 1, 'handles 1 request');
+      assert.equal(server.handledRequests[0].requestHeaders.Authorization, 'token abc123', 'has the authorization token');
     });
   });
 });
 
 test('getting a repository\'s owner', function (assert) {
+  assert.expect(14);
+
   container.lookup('service:github-session').set('githubAccessToken', 'abc123');
   server.get('/repos/user1/repository1', () => {
     return [200, {}, Factory.build('repository')];
@@ -90,14 +98,16 @@ test('getting a repository\'s owner', function (assert) {
     return store.findRecord('githubRepository', 'user1/repository1').then((repository) => {
       return repository.get('owner').then(function (owner) {
         assertGithubUserOk(assert, owner);
-        assert.equal(server.handledRequests.length, 2);
-        assert.equal(server.handledRequests[0].requestHeaders.Authorization, 'token abc123');
+        assert.equal(server.handledRequests.length, 2, 'handles 2 requests');
+        assert.equal(server.handledRequests[0].requestHeaders.Authorization, 'token abc123', 'has the authorization token');
       });
     });
   });
 });
 
 test('getting a repository\'s default branch', function (assert) {
+  assert.expect(4);
+
   container.lookup('service:github-session').set('githubAccessToken', 'abc123');
   server.get('/repos/user1/repository1', () => {
     return [200, {}, Factory.build('repository')];
@@ -110,14 +120,16 @@ test('getting a repository\'s default branch', function (assert) {
     return store.findRecord('githubRepository', 'user1/repository1').then((repository) => {
       return repository.get('defaultBranch').then(function (branch) {
         assertGithubBranchOk(assert, branch);
-        assert.equal(server.handledRequests.length, 2);
-        assert.equal(server.handledRequests[0].requestHeaders.Authorization, 'token abc123');
+        assert.equal(server.handledRequests.length, 2, 'handles 2 requests');
+        assert.equal(server.handledRequests[0].requestHeaders.Authorization, 'token abc123', 'has the authorization token');
       });
     });
   });
 });
 
 test('finding a repository\'s branches', function (assert) {
+  assert.expect(5);
+
   container.lookup('service:github-session').set('githubAccessToken', 'abc123');
   server.get('/repos/user1/repository1', () => {
     return [200, {}, Factory.build('repository')];
@@ -133,12 +145,39 @@ test('finding a repository\'s branches', function (assert) {
   return run(() => {
     return store.findRecord('githubRepository', 'user1/repository1').then((repository) => {
       return repository.get('branches').then(function (branches) {
-        assert.equal(branches.get('length'), 2);
+        assert.equal(branches.get('length'), 2, 'loads 2 branches');
         assertGithubBranchOk(assert, branches.toArray()[0]);
-        assert.equal(server.handledRequests.length, 2);
-        assert.equal(server.handledRequests[1].requestHeaders.Authorization, 'token abc123');
+        assert.equal(server.handledRequests.length, 2, 'handles 2 requests');
+        assert.equal(server.handledRequests[1].requestHeaders.Authorization, 'token abc123', 'has the authorization token');
       });
     });
   });
 });
 
+
+test('finding a repository\'s releases', function (assert) {
+  assert.expect(18);
+
+  container.lookup('service:github-session').set('githubAccessToken', 'abc123');
+  server.get('/repos/user1/repository1', () => {
+    return [200, {}, Factory.build('repository')];
+  });
+  server.get('/repos/user1/repository1/releases', () => {
+    let response = [
+      Factory.build('release'),
+      Factory.build('release')
+    ];
+    return [200, {}, response];
+  });
+
+  return run(() => {
+    return store.findRecord('githubRepository', 'user1/repository1').then((repository) => {
+      return repository.get('releases').then(function (releases) {
+        assert.equal(releases.get('length'), 2, 'loads 2 releases');
+        assertGithubReleaseOk(assert, releases.toArray()[0]);
+        assert.equal(server.handledRequests.length, 2, 'handles 2 requests');
+        assert.equal(server.handledRequests[1].requestHeaders.Authorization, 'token abc123', 'has the authorization token');
+      });
+    });
+  });
+});

--- a/tests/helpers/custom-helpers/assert-github-release-ok.js
+++ b/tests/helpers/custom-helpers/assert-github-release-ok.js
@@ -1,0 +1,22 @@
+import Ember from 'ember';
+
+export default Ember.Test.registerHelper(
+  'assertGithubReleaseOk',
+  function (app, assert, release) {
+    assert.ok(release.get('id'), 'id');
+    assert.ok(release.get('url'), 'url');
+    assert.ok(release.get('htmlUrl'), 'htmlUrl');
+    assert.ok(release.get('assetsUrl'), 'assetsUrl');
+    assert.ok(release.get('uploadUrl'), 'uploadUrl');
+    assert.ok(release.get('tarballUrl'), 'tarballUrl');
+    assert.ok(release.get('zipballUrl'), 'zipballUrl');
+    assert.ok(release.get('tagName'), 'tagName');
+    assert.ok(release.get('targetCommitish'), 'targetCommitish');
+    assert.ok(release.get('name'), 'name');
+    assert.ok(release.get('body'), 'body');
+    assert.ok(release.get('draft'), 'draft');
+    assert.ok(release.get('prerelease'), 'prerelease');
+    assert.ok(release.get('createdAt'), 'createdAt');
+    assert.ok(release.get('publishedAt'), 'publishedAt');
+  }
+);

--- a/tests/helpers/custom-helpers/assert-github-user-ok.js
+++ b/tests/helpers/custom-helpers/assert-github-user-ok.js
@@ -14,5 +14,6 @@ export default Ember.Test.registerHelper(
     assert.ok(user.get('following'));
     assert.ok(user.get('createdAt'));
     assert.ok(user.get('updatedAt'));
+    assert.ok(user.get('url'));
   }
 );

--- a/tests/helpers/factories/release.js
+++ b/tests/helpers/factories/release.js
@@ -1,0 +1,39 @@
+let sampleDate = new Date().toISOString();
+
+export default {
+  defineRelease() {
+    Factory.define('release')
+      .sequence('id')
+      .sequence('tag_name', function(i) {
+        return `v1.0.${i}`;
+      })
+      .sequence('url', function(i) {
+        return `https://api.github.com/repos/user1/repository1/releases/${i}`;
+      })
+      .sequence('html_url', function(i) {
+        return `https://github.com/repos/user1/repository1/releases/$v1.0.${i}`;
+      })
+      .sequence('assets_url', function(i) {
+        return `https://api.github.com/repos/user1/repository1/releases/${i}/assets`;
+      })
+      .sequence('upload_url', function(i) {
+        return `https://uploads.github.com/repos/user1/repository1/releases/${i}/assets{?name,label}`;
+      })
+      .sequence('tarball_url', function(i) {
+        return `https://api.github.com/repos/user1/repository1/tarball/v1.0.${i}`;
+      })
+      .sequence('zipball_url', function(i) {
+        return `https://api.github.com/repos/user1/repository1/zipball/v1.0.${i}`;
+      })
+      .attr('target_commitish', 'master')
+      .sequence('name', function(i) {
+        return `release${i}`;
+      })
+      .attr('body', 'release body')
+      .attr('draft', true)
+      .attr('prerelease', true)
+      .attr('created_at', sampleDate)
+      .attr('published_at', sampleDate)
+      .attr('author', { url: 'https://api.github.com/users/user1' })
+  }
+};

--- a/tests/helpers/factories/user.js
+++ b/tests/helpers/factories/user.js
@@ -19,6 +19,9 @@ export default {
       .attr('updated_at', SAMPLE_DATE)
       .sequence('repos_url', function (i) {
         return `https://api.github.com/users/user${i}/repos`;
+      })
+      .sequence('url', function (i) {
+        return `https://api.github.com/users/user${i}`;
       });
   }
 };

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -8,12 +8,14 @@ import UserFactory from './factories/user';
 import OrganizationFactory from './factories/organization';
 import RepositoryFactory from './factories/repository';
 import BranchFactory from './factories/branch';
+import ReleaseFactory from './factories/release';
 
 /* eslint-disable no-unused-vars */
 import assertGithubBranchOk from './custom-helpers/assert-github-branch-ok';
 import assertGithubOrganizationOk from './custom-helpers/assert-github-organization-ok';
 import assertGithubRepositoryOk from './custom-helpers/assert-github-repository-ok';
 import assertGithubUserOk from './custom-helpers/assert-github-user-ok';
+import assertGithubReleaseOk from './custom-helpers/assert-github-release-ok';
 /* eslint-enable no-unused-vars */
 
 const { merge, run } = Ember;
@@ -34,6 +36,7 @@ export default function startApp(attrs) {
   OrganizationFactory.defineOrganization();
   RepositoryFactory.defineRepository();
   BranchFactory.defineBranch();
+  ReleaseFactory.defineRelease();
 
   // Pretender doesn't work with fully qualified URLs
   GithubAdapter.reopen({

--- a/tests/unit/adapters/github-release-test.js
+++ b/tests/unit/adapters/github-release-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('adapter:github-release', 'Unit | Adapter | github release', {
+  // Specify the other units that are required for this test.
+  // needs: ['serializer:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let adapter = this.subject();
+  assert.ok(adapter);
+});

--- a/tests/unit/models/github-release-test.js
+++ b/tests/unit/models/github-release-test.js
@@ -1,0 +1,12 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('github-release', 'Unit | Model | github release', {
+  // Specify the other units that are required for this test.
+  needs: []
+});
+
+test('it exists', function(assert) {
+  let model = this.subject();
+  // let store = this.store();
+  assert.ok(!!model);
+});

--- a/tests/unit/models/github-repository-test.js
+++ b/tests/unit/models/github-repository-test.js
@@ -5,7 +5,8 @@ moduleForModel('github-repository', 'Unit | Model | github repository', {
   needs: [
     'model:githubUser',
     'model:githubBranch',
-    'model:githubPull'
+    'model:githubPull',
+    'model:githubRelease'
   ]
 });
 

--- a/tests/unit/serializers/github-release-test.js
+++ b/tests/unit/serializers/github-release-test.js
@@ -1,0 +1,15 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('github-release', 'Unit | Serializer | github release', {
+  // Specify the other units that are required for this test.
+  needs: ['serializer:github-release']
+});
+
+// Replace this with your real tests.
+test('it serializes records', function(assert) {
+  let record = this.subject();
+
+  let serializedRecord = record.serialize();
+
+  assert.ok(serializedRecord);
+});

--- a/tests/unit/serializers/github-repository-test.js
+++ b/tests/unit/serializers/github-repository-test.js
@@ -6,7 +6,8 @@ moduleForModel('github-repository', 'Unit | Serializer | github repository', {
     'serializer:github-repository',
     'model:githubBranch',
     'model:githubUser',
-    'model:githubPull'
+    'model:githubPull',
+    'model:githubRelease'
   ]
 });
 


### PR DESCRIPTION
This PR adds the necessary models/adapters/serializers to retrieve a repository's releases.

I built this so one can use `query` and `queryRecord` to retrieve record(s) since in my experience that makes it easier to find records that depend on some parent object - in this case `releases` always rely on a repository being part of the request.  If you have any insight in a way to do this with `find` and `findRecord` I'd be very interested in learning more about that.

Otherwise I tried to mimic how the other models are setup and tested.