### PR TITLE
Pagination support

### DIFF
--- a/addon/adapters/github.js
+++ b/addon/adapters/github.js
@@ -2,7 +2,7 @@ import DS from 'ember-data';
 import Ember from 'ember';
 
 const { RESTAdapter } = DS;
-const { computed, inject } = Ember;
+const { computed, inject, isNone } = Ember;
 
 export default RESTAdapter.extend({
 
@@ -20,6 +20,39 @@ export default RESTAdapter.extend({
 
   pathForType(type) {
     return Ember.String.camelize(Ember.String.pluralize(type.replace('github', '')));
-  }
+  },
 
+  // Parse Link response header out into an object like:
+  //   {
+  //     first: 'https://api.github.com/resouce?page=1&per_page=5',
+  //     next:  'https://api.github.com/resouce?page=3&per_page=5',
+  //     prev:  'https://api.github.com/resouce?page=1&per_page=5',
+  //     last:  'https://api.github.com/resouce?page=4&per_page=5',
+  //   }
+  //
+  handleResponse(status, headers, payload, requestData) {
+    const linkHeader = headers.Link;
+    const result = this._super(status, headers, payload, requestData);
+    if (isNone(linkHeader)) {
+      return result;
+    }
+
+    const links = linkHeader.split(', ').reduce((memo, link) => {
+      let [url, rel] = link.split('; ');
+
+      try {
+        [, url] = url.match(/<(.+)>/);
+        [, rel] = rel.match(/rel=\"(.+)\"/);
+      } catch(error) {
+        // Any error in parsing should not cause the application to error
+        return;
+      }
+
+      memo[rel] = url;
+      return memo;
+    }, {});
+
+    result.links = links;
+    return result;
+  }
 });

--- a/addon/serializers/github.js
+++ b/addon/serializers/github.js
@@ -1,7 +1,7 @@
 import DS from 'ember-data';
 import Ember from 'ember';
 
-const { isArray, String:Str } = Ember;
+const { isArray, String:Str, get, isNone } = Ember;
 
 export default DS.RESTSerializer.extend({
 
@@ -14,5 +14,34 @@ export default DS.RESTSerializer.extend({
     }
     wrappedPayload[fieldName] = payload;
     return this._super(store, primaryModelClass, wrappedPayload, id, requestType);
+  },
+
+  // Add metadata to the response for use with pagination. Formatted like:
+  //   {
+  //     first: { page: 1, per_page: 5 }
+  //     next:  { page: 3, per_page: 5 },
+  //     prev:  { page: 1, per_page: 5 },
+  //     last:  { page: 3, per_page: 5 }
+  //   }
+  //
+  extractMeta(store, modelClass, payload) {
+    const links = get(payload, `${Str.pluralize(modelClass.modelName)}.links`);
+
+    if (isNone(links)) {
+      return;
+    }
+
+    return Object.keys(links).reduce((meta, name) => {
+      const link = links[name];
+      const qs = link.split('?').pop();
+
+      meta[name] = qs.split('&').reduce((memo, str) => {
+        const [key, value] = str.split('=');
+        memo[key] = parseInt(value, 10);
+        return memo;
+      }, {});
+
+      return meta;
+    }, {});
   }
 });

--- a/tests/unit/adapters/github-test.js
+++ b/tests/unit/adapters/github-test.js
@@ -39,3 +39,38 @@ test('it transforms type names correctly', function(assert) {
   assert.equal(adapter.pathForType('github-user'), 'users');
   assert.equal(adapter.pathForType('github-user-name'), 'userNames');
 });
+
+test('it extracts links from the Link header', function(assert) {
+  let adapter = this.subject();
+  let first = '<https://api.github.com/resouce?page=1&per_page=5>; rel="first"';
+  let next = '<https://api.github.com/resouce?page=3&per_page=5>; rel="next"';
+  let prev = '<https://api.github.com/resouce?page=1&per_page=5>; rel="prev"';
+  let last = '<https://api.github.com/resouce?page=4&per_page=5>; rel="last"';
+
+  let headers = {
+    Link: [first, next, prev, last].join(', ')
+  };
+
+  assert.deepEqual(adapter.handleResponse(200, headers, {}, null).links, {
+    first: 'https://api.github.com/resouce?page=1&per_page=5',
+    next: 'https://api.github.com/resouce?page=3&per_page=5',
+    prev: 'https://api.github.com/resouce?page=1&per_page=5',
+    last: 'https://api.github.com/resouce?page=4&per_page=5'
+  });
+});
+
+test('it handles a missing Link header', function(assert) {
+  let adapter = this.subject();
+  let headers = {};
+
+  assert.equal(adapter.handleResponse(200, headers, {}, null).links, undefined);
+});
+
+test('it handles a mis-formed Link header', function(assert) {
+  let adapter = this.subject();
+  let headers = {
+    Link: 'well_this-is|unexpected'
+  }
+
+  assert.equal(adapter.handleResponse(200, headers, {}, null).links, undefined);
+});

--- a/tests/unit/serializers/github-test.js
+++ b/tests/unit/serializers/github-test.js
@@ -1,0 +1,40 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('serializer:github', 'Unit | Serializer | github', {
+  // Specify the other units that are required for this test.
+  needs: []
+});
+
+test('extracts pagination metadata from payload.links', function (assert) {
+  let serializer = this.subject();
+  let modelClass = { modelName: 'my-model' };
+
+  let payload = {
+    'my-models': [ { id: 1 }, { id: 2 } ]
+  };
+
+  payload['my-models'].links = {
+    first: 'https://api.github.com/resouce?page=1&per_page=5',
+    next: 'https://api.github.com/resouce?page=3&per_page=5',
+    prev: 'https://api.github.com/resouce?page=1&per_page=5',
+    last: 'https://api.github.com/resouce?page=4&per_page=5'
+  };
+
+  assert.deepEqual(serializer.extractMeta(null, modelClass, payload), {
+    first: { page: 1, per_page: 5 },
+    next: { page: 3, per_page: 5 },
+    prev: { page: 1, per_page: 5 },
+    last: { page: 4, per_page: 5 }
+  });
+});
+
+test('it handles a missing payload.links property', function (assert) {
+  let serializer = this.subject();
+  let modelClass = { modelName: 'my-model' };
+
+  let payload = {
+    'my-models': [ { id: 1 }, { id: 2 } ]
+  };
+
+  assert.equal(serializer.extractMeta(null, modelClass, payload), undefined);
+});


### PR DESCRIPTION
This PR adds support for [GitHub API pagination](https://developer.github.com/guides/traversing-with-pagination/) in two steps:

1. Parse and extract the contents of the `Link` response header into a hash of pagination links in the base adapter and add a `links` hash to the payload. I think this is required as there's no access to response headers from the serializer.
2. Next, extract pagination information from the `links` hash into the `meta` property for use in the application.

Example usage to fetch two pages:

```js
this.store.query('github-branch', {
  repo: 'some/repo',
  page: 1,
  per_page: 100
}).then((branches) => {
  const next = branches.get('meta.next');
  if (next) {
    this.store.query('github-branch', {
      repo: 'some/repo',
      page: next.page,
      per_page: next.per_page
    })
  }
});
```