### PR TITLE
Silence the test warnings

### DIFF
--- a/tests/.eslintrc.js
+++ b/tests/.eslintrc.js
@@ -1,12 +1,5 @@
 module.exports = {
   env: {
     'embertest': true
-  },
-  globals: {
-    'assertGithubUserOk':false,
-    'assertGithubRepositoryOk': false,
-    'assertGithubBranchOk': false,
-    'assertGithubReleaseOk': false,
-    'assertGithubOrganizationOk': false
   }
 };

--- a/tests/.eslintrc.js
+++ b/tests/.eslintrc.js
@@ -1,5 +1,13 @@
 module.exports = {
   env: {
     'embertest': true
+  },
+  globals: {
+    'Factory': false,
+    'assertGithubUserOk':false,
+    'assertGithubRepositoryOk': false,
+    'assertGithubBranchOk': false,
+    'assertGithubReleaseOk': false,
+    'assertGithubOrganizationOk': false
   }
 };

--- a/tests/.eslintrc.js
+++ b/tests/.eslintrc.js
@@ -3,7 +3,6 @@ module.exports = {
     'embertest': true
   },
   globals: {
-    'Factory': false,
     'assertGithubUserOk':false,
     'assertGithubRepositoryOk': false,
     'assertGithubBranchOk': false,

--- a/tests/acceptance/current-github-user-test.js
+++ b/tests/acceptance/current-github-user-test.js
@@ -55,7 +55,7 @@ test(`finding current user's repositories`, function (assert) {
     return store.findRecord('githubUser', '#').then((user) => {
       return user.get('githubRepositories').then((repositories) => {
         assert.equal(repositories.get('length'), 2);
-        assertGithubRepositoryOk(assert, repositories.toArray()[0]);
+        assert.githubRepositoryOk(repositories.toArray()[0]);
         assert.equal(server.handledRequests.length, 2);
         assert.equal(server.handledRequests[1].requestHeaders.Authorization, 'token abc123');
       });

--- a/tests/acceptance/current-github-user-test.js
+++ b/tests/acceptance/current-github-user-test.js
@@ -34,7 +34,7 @@ moduleForAcceptance('Acceptance | current github user', {
 test('finding current user', function (assert) {
   return run(() => {
     return store.findRecord('githubUser', '#').then((user) => {
-      assertGithubUserOk(assert, user);
+      assert.githubUserOk(user);
       assert.equal(store.peekAll('githubUser').get('length'), 1);
       assert.equal(server.handledRequests.length, 1);
       assert.equal(server.handledRequests[0].requestHeaders.Authorization, 'token abc123');

--- a/tests/acceptance/current-github-user-test.js
+++ b/tests/acceptance/current-github-user-test.js
@@ -1,3 +1,4 @@
+/* global Factory */
 import { test } from 'qunit';
 import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
 import startApp from 'dummy/tests/helpers/start-app';

--- a/tests/acceptance/github-branch-test.js
+++ b/tests/acceptance/github-branch-test.js
@@ -1,3 +1,4 @@
+/* global Factory */
 import { test } from 'qunit';
 import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
 import startApp from 'dummy/tests/helpers/start-app';

--- a/tests/acceptance/github-branch-test.js
+++ b/tests/acceptance/github-branch-test.js
@@ -34,7 +34,7 @@ test('finding a branch without authorization', function (assert) {
 
   return run(() => {
     return store.findRecord('githubBranch', 'User1/Repository1/branches/Branch1').then((branch) => {
-      assertGithubBranchOk(assert, branch);
+      assert.githubBranchOk(branch);
       assert.equal(store.peekAll('githubBranch').get('length'), 1);
       assert.equal(server.handledRequests.length, 1);
       assert.equal(server.handledRequests[0].requestHeaders.Authorization, undefined);
@@ -50,7 +50,7 @@ test('finding a branch', function (assert) {
 
   return run(() => {
     return store.findRecord('githubBranch', 'user1/repository1/branches/branch1').then((branch) => {
-      assertGithubBranchOk(assert, branch);
+      assert.githubBranchOk(branch);
       assert.equal(store.peekAll('githubBranch').get('length'), 1);
       assert.equal(server.handledRequests.length, 1);
       assert.equal(server.handledRequests[0].requestHeaders.Authorization, 'token abc123');

--- a/tests/acceptance/github-organization-test.js
+++ b/tests/acceptance/github-organization-test.js
@@ -1,3 +1,4 @@
+/* global Factory */
 import { test } from 'qunit';
 import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
 import startApp from 'dummy/tests/helpers/start-app';

--- a/tests/acceptance/github-organization-test.js
+++ b/tests/acceptance/github-organization-test.js
@@ -34,7 +34,7 @@ test('finding an organization without authorization', function (assert) {
 
   return run(() => {
     return store.findRecord('githubOrganization', 'Organization1').then((organization) => {
-      assertGithubOrganizationOk(assert, organization);
+      assert.githubOrganizationOk(organization);
       assert.equal(store.peekAll('githubOrganization').get('length'), 1);
       assert.equal(server.handledRequests.length, 1);
       assert.equal(server.handledRequests[0].requestHeaders.Authorization, undefined);
@@ -50,7 +50,7 @@ test('finding an organization', function (assert) {
 
   return run(() => {
     return store.findRecord('githubOrganization', 'organization1').then((organization) => {
-      assertGithubOrganizationOk(assert, organization);
+      assert.githubOrganizationOk(organization);
       assert.equal(store.peekAll('githubOrganization').get('length'), 1);
       assert.equal(server.handledRequests.length, 1);
       assert.equal(server.handledRequests[0].requestHeaders.Authorization, 'token abc123');

--- a/tests/acceptance/github-organization-test.js
+++ b/tests/acceptance/github-organization-test.js
@@ -75,7 +75,7 @@ test(`finding an organization's repositories`, function (assert) {
     return store.findRecord('githubOrganization', 'organization1').then((organization) => {
       return organization.get('githubRepositories').then(function (repositories) {
         assert.equal(repositories.get('length'), 2);
-        assertGithubRepositoryOk(assert, repositories.toArray()[0]);
+        assert.githubRepositoryOk(repositories.toArray()[0]);
         assert.equal(server.handledRequests.length, 2);
         assert.equal(server.handledRequests[1].requestHeaders.Authorization, 'token abc123');
       });

--- a/tests/acceptance/github-release-test.js
+++ b/tests/acceptance/github-release-test.js
@@ -28,7 +28,7 @@ moduleForAcceptance('Acceptance | github release', {
 });
 
 test('finding a release without authorization', function (assert) {
-  assert.expect(18);
+  assert.expect(4);
 
   server.get('/repos/user1/repository1/releases/1', () => {
     return [200, {}, Factory.build('release')];
@@ -36,7 +36,7 @@ test('finding a release without authorization', function (assert) {
 
   return run(() => {
     return store.queryRecord('githubRelease', { repo: 'user1/repository1', releaseId: '1' }).then((release) => {
-      assertGithubReleaseOk(assert, release);
+      assert.githubReleaseOk(release);
       assert.equal(store.peekAll('githubRelease').get('length'), 1, 'loads 1 release');
       assert.equal(server.handledRequests.length, 1, 'handles 1 request');
       assert.equal(server.handledRequests[0].requestHeaders.Authorization, undefined, 'has no authorization token');
@@ -45,7 +45,7 @@ test('finding a release without authorization', function (assert) {
 });
 
 test('finding a release', function (assert) {
-  assert.expect(18);
+  assert.expect(4);
 
   container.lookup('service:github-session').set('githubAccessToken', 'abc123');
   server.get('/repos/user1/repository1/releases/1', () => {
@@ -54,7 +54,7 @@ test('finding a release', function (assert) {
 
   return run(() => {
     return store.queryRecord('githubRelease', { repo: 'user1/repository1', releaseId: '1' }).then((release) => {
-      assertGithubReleaseOk(assert, release);
+      assert.githubReleaseOk(release);
       assert.equal(store.peekAll('githubRelease').get('length'), 1, 'loads 1 release');
       assert.equal(server.handledRequests.length, 1, 'handles 1 request');
       assert.equal(server.handledRequests[0].requestHeaders.Authorization, 'token abc123', 'has the authorization token');
@@ -63,7 +63,7 @@ test('finding a release', function (assert) {
 });
 
 test('finding all releases', function (assert) {
-  assert.expect(18);
+  assert.expect(4);
 
   container.lookup('service:github-session').set('githubAccessToken', 'abc123');
   server.get('/repos/user1/repository1/releases', () => {
@@ -77,7 +77,7 @@ test('finding all releases', function (assert) {
 
   return run(() => {
     return store.query('githubRelease', { repo: 'user1/repository1' }).then((releases) => {
-      assertGithubReleaseOk(assert, releases.toArray()[0]);
+      assert.githubReleaseOk(releases.toArray()[0]);
       assert.equal(store.peekAll('githubRelease').get('length'), 2, 'loads 2 releases');
       assert.equal(server.handledRequests.length, 1, 'handles 1 request');
       assert.equal(server.handledRequests[0].requestHeaders.Authorization, 'token abc123', 'has the authorization token');

--- a/tests/acceptance/github-release-test.js
+++ b/tests/acceptance/github-release-test.js
@@ -1,3 +1,4 @@
+/* global Factory */
 import { test } from 'qunit';
 import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
 import startApp from 'dummy/tests/helpers/start-app';

--- a/tests/acceptance/github-release-test.js
+++ b/tests/acceptance/github-release-test.js
@@ -86,7 +86,7 @@ test('finding all releases', function (assert) {
 });
 
 test('getting a releases\' author', function (assert) {
-  assert.expect(15);
+  assert.expect(4);
 
   container.lookup('service:github-session').set('githubAccessToken', 'abc123');
   server.get('/repos/user1/repository1/releases/1', () => {
@@ -99,7 +99,7 @@ test('getting a releases\' author', function (assert) {
   return run(() => {
     return store.queryRecord('githubRelease', { repo: 'user1/repository1', releaseId: '1' }).then((release) => {
       return release.get('user').then(function (user) {
-        assertGithubUserOk(assert, user);
+        assert.githubUserOk(user);
         assert.equal(store.peekAll('githubUser').get('length'), 1, 'loads 1 user');
         assert.equal(server.handledRequests.length, 2, 'handles 2 requests');
         assert.equal(server.handledRequests[0].requestHeaders.Authorization, 'token abc123', 'has the authorization token');

--- a/tests/acceptance/github-repository-test.js
+++ b/tests/acceptance/github-repository-test.js
@@ -55,7 +55,7 @@ test('finding a repository', function (assert) {
   return run(() => {
     return store.findRecord('githubRepository', 'user1/repository1').then((repository) => {
       assertGithubRepositoryOk(assert, repository);
-      assert.equal(store.peekAll('githubRepository').get('length'), 1), 'loads 1 repository';
+      assert.equal(store.peekAll('githubRepository').get('length'), 1, 'loads 1 repository');
       assert.equal(server.handledRequests.length, 1, 'handles 1 request');
       assert.equal(server.handledRequests[0].requestHeaders.Authorization, 'token abc123', 'has the authorization token');
     });

--- a/tests/acceptance/github-repository-test.js
+++ b/tests/acceptance/github-repository-test.js
@@ -28,7 +28,7 @@ moduleForAcceptance('Acceptance | github repository', {
 });
 
 test('finding a repository without authorization', function (assert) {
-  assert.expect(12);
+  assert.expect(4);
 
   server.get('/repos/User1/Repository1', () => {
     return [200, {}, Factory.build('repository')];
@@ -36,7 +36,7 @@ test('finding a repository without authorization', function (assert) {
 
   return run(() => {
     return store.findRecord('githubRepository', 'User1/Repository1').then((repository) => {
-      assertGithubRepositoryOk(assert, repository);
+      assert.githubRepositoryOk(repository);
       assert.equal(store.peekAll('githubRepository').get('length'), 1, 'loads 1 repository');
       assert.equal(server.handledRequests.length, 1, 'handles 1 request');
       assert.equal(server.handledRequests[0].requestHeaders.Authorization, undefined, 'has no authorization token');
@@ -45,7 +45,7 @@ test('finding a repository without authorization', function (assert) {
 });
 
 test('finding a repository', function (assert) {
-  assert.expect(12);
+  assert.expect(4);
 
   container.lookup('service:github-session').set('githubAccessToken', 'abc123');
   server.get('/repos/user1/repository1', () => {
@@ -54,7 +54,7 @@ test('finding a repository', function (assert) {
 
   return run(() => {
     return store.findRecord('githubRepository', 'user1/repository1').then((repository) => {
-      assertGithubRepositoryOk(assert, repository);
+      assert.githubRepositoryOk(repository);
       assert.equal(store.peekAll('githubRepository').get('length'), 1, 'loads 1 repository');
       assert.equal(server.handledRequests.length, 1, 'handles 1 request');
       assert.equal(server.handledRequests[0].requestHeaders.Authorization, 'token abc123', 'has the authorization token');
@@ -63,7 +63,7 @@ test('finding a repository', function (assert) {
 });
 
 test('finding all repositories', function (assert) {
-  assert.expect(12);
+  assert.expect(4);
 
   container.lookup('service:github-session').set('githubAccessToken', 'abc123');
   server.get('/repositories', () => {
@@ -77,7 +77,7 @@ test('finding all repositories', function (assert) {
   return run(() => {
     return store.findAll('githubRepository').then(function (repositories) {
       assert.equal(repositories.get('length'), 2, 'loads 2 repositories');
-      assertGithubRepositoryOk(assert, repositories.toArray()[0]);
+      assert.githubRepositoryOk(repositories.toArray()[0]);
       assert.equal(server.handledRequests.length, 1, 'handles 1 request');
       assert.equal(server.handledRequests[0].requestHeaders.Authorization, 'token abc123', 'has the authorization token');
     });

--- a/tests/acceptance/github-repository-test.js
+++ b/tests/acceptance/github-repository-test.js
@@ -1,3 +1,4 @@
+/* global Factory */
 import { test } from 'qunit';
 import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
 import startApp from 'dummy/tests/helpers/start-app';

--- a/tests/acceptance/github-repository-test.js
+++ b/tests/acceptance/github-repository-test.js
@@ -157,7 +157,7 @@ test('finding a repository\'s branches', function (assert) {
 
 
 test('finding a repository\'s releases', function (assert) {
-  assert.expect(18);
+  assert.expect(4);
 
   container.lookup('service:github-session').set('githubAccessToken', 'abc123');
   server.get('/repos/user1/repository1', () => {
@@ -175,7 +175,7 @@ test('finding a repository\'s releases', function (assert) {
     return store.findRecord('githubRepository', 'user1/repository1').then((repository) => {
       return repository.get('releases').then(function (releases) {
         assert.equal(releases.get('length'), 2, 'loads 2 releases');
-        assertGithubReleaseOk(assert, releases.toArray()[0]);
+        assert.githubReleaseOk(releases.toArray()[0]);
         assert.equal(server.handledRequests.length, 2, 'handles 2 requests');
         assert.equal(server.handledRequests[1].requestHeaders.Authorization, 'token abc123', 'has the authorization token');
       });

--- a/tests/acceptance/github-repository-test.js
+++ b/tests/acceptance/github-repository-test.js
@@ -107,7 +107,7 @@ test('getting a repository\'s owner', function (assert) {
 });
 
 test('getting a repository\'s default branch', function (assert) {
-  assert.expect(4);
+  assert.expect(3);
 
   container.lookup('service:github-session').set('githubAccessToken', 'abc123');
   server.get('/repos/user1/repository1', () => {
@@ -120,7 +120,7 @@ test('getting a repository\'s default branch', function (assert) {
   return run(() => {
     return store.findRecord('githubRepository', 'user1/repository1').then((repository) => {
       return repository.get('defaultBranch').then(function (branch) {
-        assertGithubBranchOk(assert, branch);
+        assert.githubBranchOk(branch);
         assert.equal(server.handledRequests.length, 2, 'handles 2 requests');
         assert.equal(server.handledRequests[0].requestHeaders.Authorization, 'token abc123', 'has the authorization token');
       });
@@ -129,7 +129,7 @@ test('getting a repository\'s default branch', function (assert) {
 });
 
 test('finding a repository\'s branches', function (assert) {
-  assert.expect(5);
+  assert.expect(4);
 
   container.lookup('service:github-session').set('githubAccessToken', 'abc123');
   server.get('/repos/user1/repository1', () => {
@@ -147,7 +147,7 @@ test('finding a repository\'s branches', function (assert) {
     return store.findRecord('githubRepository', 'user1/repository1').then((repository) => {
       return repository.get('branches').then(function (branches) {
         assert.equal(branches.get('length'), 2, 'loads 2 branches');
-        assertGithubBranchOk(assert, branches.toArray()[0]);
+        assert.githubBranchOk(branches.toArray()[0]);
         assert.equal(server.handledRequests.length, 2, 'handles 2 requests');
         assert.equal(server.handledRequests[1].requestHeaders.Authorization, 'token abc123', 'has the authorization token');
       });

--- a/tests/acceptance/github-repository-test.js
+++ b/tests/acceptance/github-repository-test.js
@@ -85,7 +85,7 @@ test('finding all repositories', function (assert) {
 });
 
 test('getting a repository\'s owner', function (assert) {
-  assert.expect(14);
+  assert.expect(3);
 
   container.lookup('service:github-session').set('githubAccessToken', 'abc123');
   server.get('/repos/user1/repository1', () => {
@@ -98,7 +98,7 @@ test('getting a repository\'s owner', function (assert) {
   return run(() => {
     return store.findRecord('githubRepository', 'user1/repository1').then((repository) => {
       return repository.get('owner').then(function (owner) {
-        assertGithubUserOk(assert, owner);
+        assert.githubUserOk(owner);
         assert.equal(server.handledRequests.length, 2, 'handles 2 requests');
         assert.equal(server.handledRequests[0].requestHeaders.Authorization, 'token abc123', 'has the authorization token');
       });

--- a/tests/acceptance/github-user-test.js
+++ b/tests/acceptance/github-user-test.js
@@ -34,7 +34,7 @@ test('finding a user without authorization', function (assert) {
 
   return run(() => {
     return store.findRecord('githubUser', 'User1').then((user) => {
-      assertGithubUserOk(assert, user);
+      assert.githubUserOk(user);
       assert.equal(store.peekAll('githubUser').get('length'), 1);
       assert.equal(server.handledRequests.length, 1);
       assert.equal(server.handledRequests[0].requestHeaders.Authorization, undefined);
@@ -50,7 +50,7 @@ test('finding a user', function (assert) {
 
   return run(() => {
     return store.findRecord('githubUser', 'user1').then((user) => {
-      assertGithubUserOk(assert, user);
+      assert.githubUserOk(user);
       assert.equal(store.peekAll('githubUser').get('length'), 1);
       assert.equal(server.handledRequests.length, 1);
       assert.equal(server.handledRequests[0].requestHeaders.Authorization, 'token abc123');
@@ -71,7 +71,7 @@ test('finding all users', function (assert) {
   return run(() => {
     return store.findAll('githubUser').then((users) => {
       assert.equal(users.get('length'), 2);
-      assertGithubUserOk(assert, users.toArray()[0]);
+      assert.githubUserOk(users.toArray()[0]);
       assert.equal(server.handledRequests.length, 1);
       assert.equal(server.handledRequests[0].requestHeaders.Authorization, 'token abc123');
     });

--- a/tests/acceptance/github-user-test.js
+++ b/tests/acceptance/github-user-test.js
@@ -1,3 +1,4 @@
+/* global Factory */
 import { test } from 'qunit';
 import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
 import startApp from 'dummy/tests/helpers/start-app';

--- a/tests/acceptance/github-user-test.js
+++ b/tests/acceptance/github-user-test.js
@@ -95,7 +95,7 @@ test(`finding a user's repositories`, function (assert) {
     return store.findRecord('githubUser', 'user1').then((user) => {
       return user.get('githubRepositories').then((repositories) => {
         assert.equal(repositories.get('length'), 2);
-        assertGithubRepositoryOk(assert, repositories.toArray()[0]);
+        assert.githubRepositoryOk(repositories.toArray()[0]);
         assert.equal(server.handledRequests.length, 2);
         assert.equal(server.handledRequests[1].requestHeaders.Authorization, 'token abc123');
       });

--- a/tests/helpers/custom-helpers/assert-github-branch-ok.js
+++ b/tests/helpers/custom-helpers/assert-github-branch-ok.js
@@ -1,9 +1,15 @@
+import QUnit from 'qunit';
 import Ember from 'ember';
+import assertionBuilder from '../utils/defined-attribute-assertion-builder';
+
+QUnit.assert.githubBranchOk = assertionBuilder([
+  'id',
+  'name'
+]);
 
 export default Ember.Test.registerHelper(
   'assertGithubBranchOk',
-  function (app, assert, repository) {
-    assert.ok(repository.get('id'));
-    assert.ok(repository.get('name'));
+  function (app, assert, branch) {
+    assert.githubBranchOk(branch);
   }
 );

--- a/tests/helpers/custom-helpers/assert-github-organization-ok.js
+++ b/tests/helpers/custom-helpers/assert-github-organization-ok.js
@@ -1,11 +1,17 @@
+import QUnit from 'qunit';
 import Ember from 'ember';
+import assertionBuilder from '../utils/defined-attribute-assertion-builder';
+
+QUnit.assert.githubOrganizationOk = assertionBuilder([
+  'id',
+  'login',
+  'name',
+  'avatarUrl'
+]);
 
 export default Ember.Test.registerHelper(
   'assertGithubOrganizationOk',
-  function (app, assert, user) {
-    assert.ok(user.get('id'));
-    assert.ok(user.get('login'));
-    assert.ok(user.get('name'));
-    assert.ok(user.get('avatarUrl'));
+  function (app, assert, organization) {
+    assert.githubOrganizationOk(organization);
   }
 );

--- a/tests/helpers/custom-helpers/assert-github-release-ok.js
+++ b/tests/helpers/custom-helpers/assert-github-release-ok.js
@@ -1,22 +1,28 @@
+import QUnit from 'qunit';
 import Ember from 'ember';
+import assertionBuilder from '../utils/defined-attribute-assertion-builder';
+
+QUnit.assert.githubReleaseOk = assertionBuilder([
+  'id',
+  'url',
+  'htmlUrl',
+  'assetsUrl',
+  'uploadUrl',
+  'tarballUrl',
+  'zipballUrl',
+  'tagName',
+  'targetCommitish',
+  'name',
+  'body',
+  'draft',
+  'prerelease',
+  'createdAt',
+  'publishedAt'
+]);
 
 export default Ember.Test.registerHelper(
   'assertGithubReleaseOk',
   function (app, assert, release) {
-    assert.ok(release.get('id'), 'id');
-    assert.ok(release.get('url'), 'url');
-    assert.ok(release.get('htmlUrl'), 'htmlUrl');
-    assert.ok(release.get('assetsUrl'), 'assetsUrl');
-    assert.ok(release.get('uploadUrl'), 'uploadUrl');
-    assert.ok(release.get('tarballUrl'), 'tarballUrl');
-    assert.ok(release.get('zipballUrl'), 'zipballUrl');
-    assert.ok(release.get('tagName'), 'tagName');
-    assert.ok(release.get('targetCommitish'), 'targetCommitish');
-    assert.ok(release.get('name'), 'name');
-    assert.ok(release.get('body'), 'body');
-    assert.ok(release.get('draft'), 'draft');
-    assert.ok(release.get('prerelease'), 'prerelease');
-    assert.ok(release.get('createdAt'), 'createdAt');
-    assert.ok(release.get('publishedAt'), 'publishedAt');
+    assert.githubReleaseOk(release);
   }
 );

--- a/tests/helpers/custom-helpers/assert-github-repository-ok.js
+++ b/tests/helpers/custom-helpers/assert-github-repository-ok.js
@@ -1,16 +1,22 @@
+import QUnit from 'qunit';
 import Ember from 'ember';
+import assertionBuilder from '../utils/defined-attribute-assertion-builder';
+
+QUnit.assert.githubRepositoryOk = assertionBuilder([
+  'id',
+  'fullName',
+  'name',
+  'description',
+  'fork',
+  'private',
+  'createdAt',
+  'updatedAt',
+  'pushedAt'
+]);
 
 export default Ember.Test.registerHelper(
   'assertGithubRepositoryOk',
   function (app, assert, repository) {
-    assert.ok(repository.get('id'));
-    assert.ok(repository.get('fullName'));
-    assert.ok(repository.get('name'));
-    assert.ok(repository.get('description'));
-    assert.ok(repository.get('fork'));
-    assert.ok(repository.get('private'));
-    assert.ok(repository.get('createdAt'));
-    assert.ok(repository.get('updatedAt'));
-    assert.ok(repository.get('pushedAt'));
+    assert.githubRepositoryOk(repository);
   }
 );

--- a/tests/helpers/custom-helpers/assert-github-user-ok.js
+++ b/tests/helpers/custom-helpers/assert-github-user-ok.js
@@ -1,19 +1,39 @@
+import QUnit from 'qunit';
 import Ember from 'ember';
+
+QUnit.assert.githubUserOk = function(user, message) {
+  let allDefined = true;
+  let undefinedKeys = [];
+  [
+    'id',
+    'login',
+    'name',
+    'type',
+    'avatarUrl',
+    'publicRepos',
+    'publicGists',
+    'followers',
+    'following',
+    'createdAt',
+    'updatedAt',
+    'url'
+  ].forEach(key => {
+    if( user.get(key) === undefined ) {
+      allDefined = false;
+      undefinedKeys.push(key);
+    }
+  });
+  this.pushResult({
+    result: allDefined,
+    actual: allDefined,
+    expected: true,
+    message: `${message}: ${undefinedKeys.join(',')}`
+  });
+};
 
 export default Ember.Test.registerHelper(
   'assertGithubUserOk',
   function (app, assert, user) {
-    assert.ok(user.get('id'));
-    assert.ok(user.get('login'));
-    assert.ok(user.get('name'));
-    assert.ok(user.get('type'));
-    assert.ok(user.get('avatarUrl'));
-    assert.ok(user.get('publicRepos'));
-    assert.ok(user.get('publicGists'));
-    assert.ok(user.get('followers'));
-    assert.ok(user.get('following'));
-    assert.ok(user.get('createdAt'));
-    assert.ok(user.get('updatedAt'));
-    assert.ok(user.get('url'));
+    assert.githubUserOk(user);
   }
 );

--- a/tests/helpers/custom-helpers/assert-github-user-ok.js
+++ b/tests/helpers/custom-helpers/assert-github-user-ok.js
@@ -1,35 +1,21 @@
 import QUnit from 'qunit';
 import Ember from 'ember';
+import assertionBuilder from '../utils/defined-attribute-assertion-builder';
 
-QUnit.assert.githubUserOk = function(user, message) {
-  let allDefined = true;
-  let undefinedKeys = [];
-  [
-    'id',
-    'login',
-    'name',
-    'type',
-    'avatarUrl',
-    'publicRepos',
-    'publicGists',
-    'followers',
-    'following',
-    'createdAt',
-    'updatedAt',
-    'url'
-  ].forEach(key => {
-    if( user.get(key) === undefined ) {
-      allDefined = false;
-      undefinedKeys.push(key);
-    }
-  });
-  this.pushResult({
-    result: allDefined,
-    actual: allDefined,
-    expected: true,
-    message: `${message}: ${undefinedKeys.join(',')}`
-  });
-};
+QUnit.assert.githubUserOk = assertionBuilder([
+  'id',
+  'login',
+  'name',
+  'type',
+  'avatarUrl',
+  'publicRepos',
+  'publicGists',
+  'followers',
+  'following',
+  'createdAt',
+  'updatedAt',
+  'url'
+]);
 
 export default Ember.Test.registerHelper(
   'assertGithubUserOk',

--- a/tests/helpers/factories/branch.js
+++ b/tests/helpers/factories/branch.js
@@ -1,3 +1,4 @@
+/* global Factory */
 export default {
   defineBranch() {
     Factory.define('branch')

--- a/tests/helpers/factories/organization.js
+++ b/tests/helpers/factories/organization.js
@@ -1,3 +1,4 @@
+/* global Factory */
 export default {
   defineOrganization() {
     Factory.define('organization').sequence('id')

--- a/tests/helpers/factories/release.js
+++ b/tests/helpers/factories/release.js
@@ -1,3 +1,4 @@
+/* global Factory */
 let sampleDate = new Date().toISOString();
 
 export default {

--- a/tests/helpers/factories/repository.js
+++ b/tests/helpers/factories/repository.js
@@ -1,3 +1,4 @@
+/* global Factory */
 let sampleDate = new Date().toISOString();
 export default {
   defineRepository() {

--- a/tests/helpers/factories/user.js
+++ b/tests/helpers/factories/user.js
@@ -1,3 +1,4 @@
+/* global Factory */
 const SAMPLE_DATE = new Date().toISOString();
 
 export default {

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -10,13 +10,11 @@ import RepositoryFactory from './factories/repository';
 import BranchFactory from './factories/branch';
 import ReleaseFactory from './factories/release';
 
-/* eslint-disable no-unused-vars */
-import assertGithubBranchOk from './custom-helpers/assert-github-branch-ok';
-import assertGithubOrganizationOk from './custom-helpers/assert-github-organization-ok';
-import assertGithubRepositoryOk from './custom-helpers/assert-github-repository-ok';
-import assertGithubUserOk from './custom-helpers/assert-github-user-ok';
-import assertGithubReleaseOk from './custom-helpers/assert-github-release-ok';
-/* eslint-enable no-unused-vars */
+import './custom-helpers/assert-github-branch-ok';
+import './custom-helpers/assert-github-organization-ok';
+import './custom-helpers/assert-github-repository-ok';
+import './custom-helpers/assert-github-user-ok';
+import './custom-helpers/assert-github-release-ok';
 
 const { merge, run } = Ember;
 

--- a/tests/helpers/utils/defined-attribute-assertion-builder.js
+++ b/tests/helpers/utils/defined-attribute-assertion-builder.js
@@ -1,0 +1,20 @@
+export default function(keys) {
+  return function(object, message) {
+    let allDefined = true;
+    let undefinedKeys = [];
+
+    keys.forEach(key => {
+      if (object.get(key) === undefined) {
+        allDefined = false;
+        undefinedKeys.push(key);
+      }
+    });
+    let realMessage = message || 'Undefined keys';
+    this.pushResult({
+      result: allDefined,
+      actual: allDefined,
+      expected: true,
+      message: `${realMessage}: ${undefinedKeys.join(',')}`
+    });
+  }
+}


### PR DESCRIPTION
Silence the test warnings about `Factory` and test helpers by adding eslint global declarations.

Is there a better way? I looked into `ember-rosie` and importing `Factory` but it didn't work.