### PR TITLE
Add trees API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ this.get('store').queryRecord('github-branch', { repo: 'jimmay5469/old-hash', br
 this.get('store').query('github-branch', { repo: 'jimmay5469/old-hash' }); // get a repo's branches
 this.get('store').queryRecord('github-release', { repo: 'jimmay5469/old-hash', releaseId: 1 }); // get a specific release
 this.get('store').query('github-release', { repo: 'jimmay5469/old-hash' }); // get a repo's releases
-this.get('store').queryRecord('github-blob', { user: 'jimmay5469', repo: 'old-hash', sha: '47c5438403ca875f170db2aa07d1bfa3689406e3' }); // get a file's contents
+this.get('store').queryRecord('github-blob', { repo: 'jimmay5469/old-hash', sha: '47c5438403ca875f170db2aa07d1bfa3689406e3' }); // get a file's contents
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ this.get('store').findRecord('github-branch', 'jimmay5469/old-hash/branches/mast
 this.get('store').queryRecord('github-branch', { repo: 'jimmay5469/old-hash', branch: 'master' }); // get a specific branch
 this.get('store').query('github-branch', { repo: 'jimmay5469/old-hash' }); // get a repo's branches
 this.get('store').queryRecord('github-release', { repo: 'jimmay5469/old-hash', releaseId: 1 }); // get a specific release
-this.get('store').query('github-release', { repo: 'jimmay5469/old-hash' }) // get a repo's releases
+this.get('store').query('github-release', { repo: 'jimmay5469/old-hash' }); // get a repo's releases
+this.get('store').queryRecord('github-blob', { user: 'jimmay5469', repo: 'old-hash', sha: '47c5438403ca875f170db2aa07d1bfa3689406e3' }); // get a file's contents
 ```
 
 ## Contributing

--- a/addon/adapters/github-blob.js
+++ b/addon/adapters/github-blob.js
@@ -2,13 +2,11 @@ import GithubAdapter from './github';
 
 export default GithubAdapter.extend({
   urlForQueryRecord(query) {
-    const user = query.user;
     const repo = query.repo;
     const sha = query.sha;
-    delete query.user;
     delete query.repo;
     delete query.sha;
 
-    return `${this.get('host')}/repos/${user}/${repo}/git/blobs/${sha}`;
+    return `${this.get('host')}/repos/${repo}/git/blobs/${sha}`;
   }
 });

--- a/addon/adapters/github-blob.js
+++ b/addon/adapters/github-blob.js
@@ -1,0 +1,14 @@
+import GithubAdapter from './github';
+
+export default GithubAdapter.extend({
+  urlForQueryRecord(query) {
+    const user = query.user;
+    const repo = query.repo;
+    const sha = query.sha;
+    delete query.user;
+    delete query.repo;
+    delete query.sha;
+
+    return `${this.get('host')}/repos/${user}/${repo}/git/blobs/${sha}`;
+  }
+});

--- a/addon/adapters/github-tree.js
+++ b/addon/adapters/github-tree.js
@@ -7,6 +7,10 @@ export default GithubAdapter.extend({
     delete query.repo;
     delete query.sha;
 
+    if (query.recursive) {
+      query.recursive = 1;
+    }
+
     return `${this.get('host')}/repos/${repo}/git/trees/${sha}`;
   }
 });

--- a/addon/adapters/github-tree.js
+++ b/addon/adapters/github-tree.js
@@ -1,0 +1,12 @@
+import GithubAdapter from './github';
+
+export default GithubAdapter.extend({
+  urlForQueryRecord(query) {
+    const repo = query.repo;
+    const sha = query.sha;
+    delete query.repo;
+    delete query.sha;
+
+    return `${this.get('host')}/repos/${repo}/git/trees/${sha}`;
+  }
+});

--- a/addon/models/github-blob.js
+++ b/addon/models/github-blob.js
@@ -1,0 +1,9 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  sha: DS.attr('string'),
+  url: DS.attr('string'),
+  content: DS.attr('string'),
+  encoding: DS.attr('string'),
+  size: DS.attr('number')
+});

--- a/addon/models/github-tree.js
+++ b/addon/models/github-tree.js
@@ -1,0 +1,11 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  sha: DS.attr('string'),
+  url: DS.attr('string'),
+  files: DS.attr(), // object
+  directories: DS.attr(), // object
+  blobs: DS.hasMany('github-blob', { async: true }),
+  trees: DS.hasMany('github-tree', { async: true }),
+  truncated: DS.attr('boolean')
+});

--- a/addon/serializers/github-blob.js
+++ b/addon/serializers/github-blob.js
@@ -1,0 +1,16 @@
+import GithubSerializer from './github';
+
+export default GithubSerializer.extend({
+  normalize(modelClass, resourceHash, prop) {
+    let normalizedHash = {
+      id: resourceHash.sha,
+      sha: resourceHash.sha,
+      url: resourceHash.url,
+      content: resourceHash.content,
+      encoding: resourceHash.encoding,
+      size: resourceHash.size
+    };
+
+    return this._super(modelClass, normalizedHash, prop);
+  }
+});

--- a/addon/serializers/github-tree.js
+++ b/addon/serializers/github-tree.js
@@ -1,0 +1,33 @@
+import GithubSerializer from './github';
+
+export default GithubSerializer.extend({
+  normalize(modelClass, resourceHash, prop) {
+    let normalizedHash = {
+      id: resourceHash.sha,
+      sha: resourceHash.sha,
+      url: resourceHash.url,
+      files: resourceHash.tree
+        .filter(item => item.type === 'blob')
+        .reduce((files, blob) => {
+          files[blob.path] = blob.sha;
+          return files;
+        }, {}),
+      directories: resourceHash.tree
+        .filter(item => item.type === 'tree')
+        .reduce((files, tree) => {
+          files[tree.path] = tree.sha;
+          return files;
+        }, {}),
+      truncated: resourceHash.truncated,
+      links: {
+        blobs: resourceHash.tree
+          .filter(item => item.type === 'blob')
+          .map(blob => blob.url),
+        trees: resourceHash.tree
+          .filter(item => item.type === 'tree')
+          .map(tree => tree.url)
+      }
+    };
+    return this._super(modelClass, normalizedHash, prop);
+  }
+});

--- a/addon/serializers/github-tree.js
+++ b/addon/serializers/github-tree.js
@@ -11,22 +11,18 @@ export default GithubSerializer.extend({
       id: resourceHash.sha,
       sha: resourceHash.sha,
       url: resourceHash.url,
-      files: blobItems
-        .reduce((files, blob) => {
+      files: blobItems.reduce((files, blob) => {
           files[blob.path] = blob.sha;
           return files;
         }, {}),
-      directories: treeItems
-        .reduce((files, tree) => {
+      directories: treeItems.reduce((files, tree) => {
           files[tree.path] = tree.sha;
           return files;
         }, {}),
       truncated: resourceHash.truncated,
       links: {
-        blobs: blobItems
-          .map(blob => blob.url),
-        trees: treeItems
-          .map(tree => tree.url)
+        blobs: blobItems.map(blob => blob.url),
+        trees: treeItems.map(tree => tree.url)
       }
     };
     return this._super(modelClass, normalizedHash, prop);

--- a/addon/serializers/github-tree.js
+++ b/addon/serializers/github-tree.js
@@ -2,29 +2,30 @@ import GithubSerializer from './github';
 
 export default GithubSerializer.extend({
   normalize(modelClass, resourceHash, prop) {
+    let blobItems = resourceHash.tree
+      .filter(item => item.type === 'blob');
+    let treeItems = resourceHash.tree
+      .filter(item => item.type === 'tree');
+
     let normalizedHash = {
       id: resourceHash.sha,
       sha: resourceHash.sha,
       url: resourceHash.url,
-      files: resourceHash.tree
-        .filter(item => item.type === 'blob')
+      files: blobItems
         .reduce((files, blob) => {
           files[blob.path] = blob.sha;
           return files;
         }, {}),
-      directories: resourceHash.tree
-        .filter(item => item.type === 'tree')
+      directories: treeItems
         .reduce((files, tree) => {
           files[tree.path] = tree.sha;
           return files;
         }, {}),
       truncated: resourceHash.truncated,
       links: {
-        blobs: resourceHash.tree
-          .filter(item => item.type === 'blob')
+        blobs: blobItems
           .map(blob => blob.url),
-        trees: resourceHash.tree
-          .filter(item => item.type === 'tree')
+        trees: treeItems
           .map(tree => tree.url)
       }
     };

--- a/app/adapters/github-blob.js
+++ b/app/adapters/github-blob.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-github/adapters/github-blob';

--- a/app/adapters/github-tree.js
+++ b/app/adapters/github-tree.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-github/adapters/github-tree';

--- a/app/models/github-blob.js
+++ b/app/models/github-blob.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-github/models/github-blob';

--- a/app/models/github-tree.js
+++ b/app/models/github-tree.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-github/models/github-tree';

--- a/app/serializers/github-blob.js
+++ b/app/serializers/github-blob.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-github/serializers/github-blob';

--- a/app/serializers/github-tree.js
+++ b/app/serializers/github-tree.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-github/serializers/github-tree';

--- a/tests/acceptance/github-blob-test.js
+++ b/tests/acceptance/github-blob-test.js
@@ -34,8 +34,7 @@ test('retrieving a blob', function(assert) {
 
   return run(() => {
     return store.queryRecord('github-blob', {
-      user: 'user1',
-      repo: 'repo1',
+      repo: 'user1/repo1',
       sha: '1'
     }).then(blob => {
       assert.githubBlobOk(blob);

--- a/tests/acceptance/github-blob-test.js
+++ b/tests/acceptance/github-blob-test.js
@@ -1,0 +1,47 @@
+/* global Factory */
+import { test } from 'qunit';
+import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
+import startApp from 'dummy/tests/helpers/start-app';
+import Pretender from 'pretender';
+import Ember from 'ember';
+
+const { run } = Ember;
+
+let server, app, container, store;
+
+moduleForAcceptance('Acceptance | github blob', {
+  beforeEach() {
+    server = new Pretender();
+    server.prepareBody = function (body) {
+      return JSON.stringify(body);
+    };
+    app = startApp();
+    container = app.__container__;
+    store = run(container, 'lookup', 'service:store');
+  },
+
+  afterEach() {
+    server.shutdown();
+    run(app, app.destroy);
+    Ember.BOOTED = false;
+  }
+});
+
+test('retrieving a blob', function(assert) {
+  server.get('/repos/user1/repo1/git/blobs/1', () => {
+    return [200, {}, Factory.build('blob')];
+  });
+
+  return run(() => {
+    return store.queryRecord('github-blob', {
+      user: 'user1',
+      repo: 'repo1',
+      sha: '1'
+    }).then(blob => {
+      assert.githubBlobOk(blob);
+      assert.equal(store.peekAll('githubBlob').get('length'), 1);
+      assert.equal(server.handledRequests.length, 1);
+      assert.equal(server.handledRequests[0].requestHeaders.Authorization, undefined);
+    });
+  });
+});

--- a/tests/acceptance/github-tree-test.js
+++ b/tests/acceptance/github-tree-test.js
@@ -44,3 +44,25 @@ test('retrieving a tree', function(assert) {
     });
   });
 });
+
+test('retrieving a tree recursively', function(assert) {
+  server.get('/repos/user1/repo1/git/trees/1', () => {
+    return [200, {}, Factory.build('tree')];
+  });
+
+  return run(() => {
+    return store.queryRecord('github-tree', {
+      repo: 'user1/repo1',
+      sha: '1',
+      recursive: true
+    }).then(tree => {
+      assert.githubTreeOk(tree);
+      assert.equal(store.peekAll('githubTree').get('length'), 1);
+      assert.equal(server.handledRequests.length, 1);
+      assert.equal(server.handledRequests[0].requestHeaders.Authorization, undefined);
+      assert.ok(server.handledRequests[0].queryParams);
+      assert.ok(server.handledRequests[0].queryParams.recursive);
+      assert.equal(server.handledRequests[0].queryParams.recursive, 1);
+    });
+  });
+});

--- a/tests/acceptance/github-tree-test.js
+++ b/tests/acceptance/github-tree-test.js
@@ -34,7 +34,7 @@ test('retrieving a tree', function(assert) {
 
   return run(() => {
     return store.queryRecord('github-tree', {
-      repo: 'user1/repository1',
+      repo: 'user1/repo1',
       sha: '1'
     }).then(tree => {
       assert.githubTreeOk(tree);

--- a/tests/acceptance/github-tree-test.js
+++ b/tests/acceptance/github-tree-test.js
@@ -1,0 +1,46 @@
+/* global Factory */
+import { test } from 'qunit';
+import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
+import startApp from 'dummy/tests/helpers/start-app';
+import Pretender from 'pretender';
+import Ember from 'ember';
+
+const { run } = Ember;
+
+let server, app, container, store;
+
+moduleForAcceptance('Acceptance | github tree', {
+  beforeEach() {
+    server = new Pretender();
+    server.prepareBody = function (body) {
+      return JSON.stringify(body);
+    };
+    app = startApp();
+    container = app.__container__;
+    store = run(container, 'lookup', 'service:store');
+  },
+
+  afterEach() {
+    server.shutdown();
+    run(app, app.destroy);
+    Ember.BOOTED = false;
+  }
+});
+
+test('retrieving a tree', function(assert) {
+  server.get('/repos/user1/repo1/git/trees/1', () => {
+    return [200, {}, Factory.build('tree')];
+  });
+
+  return run(() => {
+    return store.queryRecord('github-tree', {
+      repo: 'user1/repository1',
+      sha: '1'
+    }).then(tree => {
+      assert.githubTreeOk(tree);
+      assert.equal(store.peekAll('githubTree').get('length'), 1);
+      assert.equal(server.handledRequests.length, 1);
+      assert.equal(server.handledRequests[0].requestHeaders.Authorization, undefined);
+    });
+  });
+});

--- a/tests/helpers/custom-helpers/assert-github-blob-ok.js
+++ b/tests/helpers/custom-helpers/assert-github-blob-ok.js
@@ -1,0 +1,19 @@
+import QUnit from 'qunit';
+import Ember from 'ember';
+import assertionBuilder from '../utils/defined-attribute-assertion-builder';
+
+QUnit.assert.githubBlobOk = assertionBuilder([
+  'id',
+  'sha',
+  'url',
+  'content',
+  'size',
+  'encoding'
+]);
+
+export default Ember.Test.registerHelper(
+  'assertGithubBlobOk',
+  function (app, assert, blob) {
+    assert.githubBlobOk(blob);
+  }
+);

--- a/tests/helpers/custom-helpers/assert-github-tree-ok.js
+++ b/tests/helpers/custom-helpers/assert-github-tree-ok.js
@@ -1,0 +1,11 @@
+import Ember from 'ember';
+
+export default Ember.Test.registerHelper(
+  'assertGithubTreeOk',
+  function (app, assert, tree) {
+    assert.ok(tree.get('sha'));
+    assert.ok(tree.get('url'));
+    assert.ok(tree.get('tree'));
+    assert.ok(tree.get('truncated'));
+  }
+);

--- a/tests/helpers/custom-helpers/assert-github-tree-ok.js
+++ b/tests/helpers/custom-helpers/assert-github-tree-ok.js
@@ -6,7 +6,10 @@ QUnit.assert.githubTreeOk = assertionBuilder([
   'id',
   'sha',
   'url',
-  'tree',
+  'files',
+  'directories',
+  'blobs',
+  'trees',
   'truncated'
 ]);
 

--- a/tests/helpers/custom-helpers/assert-github-tree-ok.js
+++ b/tests/helpers/custom-helpers/assert-github-tree-ok.js
@@ -1,11 +1,18 @@
+import QUnit from 'qunit';
 import Ember from 'ember';
+import assertionBuilder from '../utils/defined-attribute-assertion-builder';
+
+QUnit.assert.githubTreeOk = assertionBuilder([
+  'id',
+  'sha',
+  'url',
+  'tree',
+  'truncated'
+]);
 
 export default Ember.Test.registerHelper(
   'assertGithubTreeOk',
   function (app, assert, tree) {
-    assert.ok(tree.get('sha'));
-    assert.ok(tree.get('url'));
-    assert.ok(tree.get('tree'));
-    assert.ok(tree.get('truncated'));
+    assert.githubTreeOk(tree);
   }
 );

--- a/tests/helpers/factories/blob.js
+++ b/tests/helpers/factories/blob.js
@@ -1,0 +1,24 @@
+/* global Factory */
+
+export default {
+  defineBlob() {
+    Factory.define('blob')
+      .sequence('sha')
+      .attr('url', ['sha'], function(sha) {
+        return `https://api.github.com/repos/user1/repository1/git/blobs/${sha}`;
+      })
+      .attr('content', 'IyBFZGl0b3JDb25maWcgaGVscHMgZGV2ZWxvcGVycyBkZWZpbmUgYW5kIG1h\naW50YWluIGNvbnNpc3RlbnQKIyBjb2Rpbmcgc3R5bGVzIGJldHdlZW4gZGlm\nZmVyZW50IGVkaXRvcnMgYW5kIElERXMKIyBlZGl0b3Jjb25maWcub3JnCgpy\nb290ID0gdHJ1ZQoKClsqXQplbmRfb2ZfbGluZSA9IGxmCmNoYXJzZXQgPSB1\ndGYtOAp0cmltX3RyYWlsaW5nX3doaXRlc3BhY2UgPSB0cnVlCmluc2VydF9m\naW5hbF9uZXdsaW5lID0gdHJ1ZQppbmRlbnRfc3R5bGUgPSBzcGFjZQppbmRl\nbnRfc2l6ZSA9IDIKClsqLmhic10KaW5zZXJ0X2ZpbmFsX25ld2xpbmUgPSBm\nYWxzZQoKWyoue2RpZmYsbWR9XQp0cmltX3RyYWlsaW5nX3doaXRlc3BhY2Ug\nPSBmYWxzZQo=\n')
+      .attr('encoding', 'base64')
+      .attr('size', 368);
+  }
+};
+
+/* repo: srvance/ember-bootstrap, branch: add-bs4, file: /.editorconfig
+{
+  "sha": "219985c2289f78f0a652c317ec69c2bc355ee5e9",
+  "size": 368,
+  "url": "https://api.github.com/repos/srvance/ember-bootstrap/git/blobs/219985c2289f78f0a652c317ec69c2bc355ee5e9",
+  "content": "IyBFZGl0b3JDb25maWcgaGVscHMgZGV2ZWxvcGVycyBkZWZpbmUgYW5kIG1h\naW50YWluIGNvbnNpc3RlbnQKIyBjb2Rpbmcgc3R5bGVzIGJldHdlZW4gZGlm\nZmVyZW50IGVkaXRvcnMgYW5kIElERXMKIyBlZGl0b3Jjb25maWcub3JnCgpy\nb290ID0gdHJ1ZQoKClsqXQplbmRfb2ZfbGluZSA9IGxmCmNoYXJzZXQgPSB1\ndGYtOAp0cmltX3RyYWlsaW5nX3doaXRlc3BhY2UgPSB0cnVlCmluc2VydF9m\naW5hbF9uZXdsaW5lID0gdHJ1ZQppbmRlbnRfc3R5bGUgPSBzcGFjZQppbmRl\nbnRfc2l6ZSA9IDIKClsqLmhic10KaW5zZXJ0X2ZpbmFsX25ld2xpbmUgPSBm\nYWxzZQoKWyoue2RpZmYsbWR9XQp0cmltX3RyYWlsaW5nX3doaXRlc3BhY2Ug\nPSBmYWxzZQo=\n",
+  "encoding": "base64"
+}
+*/

--- a/tests/helpers/factories/trees.js
+++ b/tests/helpers/factories/trees.js
@@ -1,3 +1,38 @@
+/* global Factory */
+
+export default {
+  defineTree() {
+    Factory.define('tree')
+      .sequence('sha')
+      .attr('url', ['sha'], function(sha) {
+        return `https://api.github.com/user1/repository1/git/trees/${sha}`;
+      })
+      .attr('tree', ['sha'], function(sha) {
+        let tree = [];
+        let fileSha = sha + 100;
+        tree.push({
+          path: "file.js",
+          mode: "100644",
+          type: "blob",
+          sha: `${fileSha}`,
+          size: 17,
+          url: `https://api.github.com/repos/user1/repository1/git/blobs/${fileSha}`
+        });
+        let treeSha = fileSha + 1;
+        tree.push({
+          path: "config",
+          mode: "040000",
+          type: "tree",
+          sha: `${treeSha}`,
+          url: `https://api.github.com/user1/repository1/git/trees/${treeSha}`
+        });
+
+        return tree;
+      })
+      .attr('truncated', false);
+  }
+}
+
 /*
 {
   "sha": "96e2b883219731e82b5a23e67c61c2ac6a3a2a4f",

--- a/tests/helpers/factories/trees.js
+++ b/tests/helpers/factories/trees.js
@@ -1,0 +1,233 @@
+/*
+{
+  "sha": "96e2b883219731e82b5a23e67c61c2ac6a3a2a4f",
+  "url": "https://api.github.com/repos/srvance/ember-bootstrap/git/trees/96e2b883219731e82b5a23e67c61c2ac6a3a2a4f",
+  "tree": [
+    {
+      "path": ".bowerrc",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "959e1696e7b2c970005c35ec8a0f94aea5df36ac",
+      "size": 60,
+      "url": "https://api.github.com/repos/srvance/ember-bootstrap/git/blobs/959e1696e7b2c970005c35ec8a0f94aea5df36ac"
+    },
+    {
+      "path": ".codeclimate.yml",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "d3b0a543dfe8f8b71e03b8fb635b1a6fbaadd205",
+      "size": 67,
+      "url": "https://api.github.com/repos/srvance/ember-bootstrap/git/blobs/d3b0a543dfe8f8b71e03b8fb635b1a6fbaadd205"
+    },
+    {
+      "path": ".editorconfig",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "219985c2289f78f0a652c317ec69c2bc355ee5e9",
+      "size": 368,
+      "url": "https://api.github.com/repos/srvance/ember-bootstrap/git/blobs/219985c2289f78f0a652c317ec69c2bc355ee5e9"
+    },
+    {
+      "path": ".ember-cli",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "ee64cfed2a8905dc23506af1060ec80cf887582d",
+      "size": 280,
+      "url": "https://api.github.com/repos/srvance/ember-bootstrap/git/blobs/ee64cfed2a8905dc23506af1060ec80cf887582d"
+    },
+    {
+      "path": ".gitignore",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "9936dc90fd24a5247efd99e1528e099854ffea3e",
+      "size": 268,
+      "url": "https://api.github.com/repos/srvance/ember-bootstrap/git/blobs/9936dc90fd24a5247efd99e1528e099854ffea3e"
+    },
+    {
+      "path": ".jscsrc",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "f2011001b778d9384f175d3505515081b96f2407",
+      "size": 69,
+      "url": "https://api.github.com/repos/srvance/ember-bootstrap/git/blobs/f2011001b778d9384f175d3505515081b96f2407"
+    },
+    {
+      "path": ".jshintrc",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "d421faa302f008117defd3bc1aee737aab78055a",
+      "size": 518,
+      "url": "https://api.github.com/repos/srvance/ember-bootstrap/git/blobs/d421faa302f008117defd3bc1aee737aab78055a"
+    },
+    {
+      "path": ".npmignore",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "75c07386ea0137971521e7e57b1525bf9dc5799e",
+      "size": 270,
+      "url": "https://api.github.com/repos/srvance/ember-bootstrap/git/blobs/75c07386ea0137971521e7e57b1525bf9dc5799e"
+    },
+    {
+      "path": ".travis.yml",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "cbb91ee09859214bd96052c9e5ed43d46ab09a39",
+      "size": 612,
+      "url": "https://api.github.com/repos/srvance/ember-bootstrap/git/blobs/cbb91ee09859214bd96052c9e5ed43d46ab09a39"
+    },
+    {
+      "path": ".watchmanconfig",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "e7834e3e4f39c1a745942dfe90891708593e0ea6",
+      "size": 37,
+      "url": "https://api.github.com/repos/srvance/ember-bootstrap/git/blobs/e7834e3e4f39c1a745942dfe90891708593e0ea6"
+    },
+    {
+      "path": "CHANGELOG.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "120588bcd164011305f5a622ed9686586b451744",
+      "size": 23829,
+      "url": "https://api.github.com/repos/srvance/ember-bootstrap/git/blobs/120588bcd164011305f5a622ed9686586b451744"
+    },
+    {
+      "path": "LICENSE.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "02000b56e60d3755718d2e3017f80913b2da9dce",
+      "size": 1066,
+      "url": "https://api.github.com/repos/srvance/ember-bootstrap/git/blobs/02000b56e60d3755718d2e3017f80913b2da9dce"
+    },
+    {
+      "path": "README.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "332bbf8183213e0551c8ca4579a1b0c7948001e2",
+      "size": 2630,
+      "url": "https://api.github.com/repos/srvance/ember-bootstrap/git/blobs/332bbf8183213e0551c8ca4579a1b0c7948001e2"
+    },
+    {
+      "path": "addon",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "d0545b5694f428fd072515f914ec5524b296a8f9",
+      "url": "https://api.github.com/repos/srvance/ember-bootstrap/git/trees/d0545b5694f428fd072515f914ec5524b296a8f9"
+    },
+    {
+      "path": "app",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "ecda62ce7dd2836356d88d2dab3cd1cb618ff126",
+      "url": "https://api.github.com/repos/srvance/ember-bootstrap/git/trees/ecda62ce7dd2836356d88d2dab3cd1cb618ff126"
+    },
+    {
+      "path": "blueprints",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "072e4221706337a87f1ed4236021067a54597e4b",
+      "url": "https://api.github.com/repos/srvance/ember-bootstrap/git/trees/072e4221706337a87f1ed4236021067a54597e4b"
+    },
+    {
+      "path": "bower.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "48b3448ae914f604c85198abd0bec650dbeed416",
+      "size": 146,
+      "url": "https://api.github.com/repos/srvance/ember-bootstrap/git/blobs/48b3448ae914f604c85198abd0bec650dbeed416"
+    },
+    {
+      "path": "config",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "9b39bd27cb2d371cee92e19fdeb654f3848d7b67",
+      "url": "https://api.github.com/repos/srvance/ember-bootstrap/git/trees/9b39bd27cb2d371cee92e19fdeb654f3848d7b67"
+    },
+    {
+      "path": "docs",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "ae303b977410829ac1ceffcf8a049c925b638f38",
+      "url": "https://api.github.com/repos/srvance/ember-bootstrap/git/trees/ae303b977410829ac1ceffcf8a049c925b638f38"
+    },
+    {
+      "path": "ember-cli-build.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "9c7d97cdeeef820be2b8bcec4ad10fe3455603d8",
+      "size": 566,
+      "url": "https://api.github.com/repos/srvance/ember-bootstrap/git/blobs/9c7d97cdeeef820be2b8bcec4ad10fe3455603d8"
+    },
+    {
+      "path": "fastboot-tests",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "5f0f2d55dc1b7de2b74c8cf7086a945bb7c48d3c",
+      "url": "https://api.github.com/repos/srvance/ember-bootstrap/git/trees/5f0f2d55dc1b7de2b74c8cf7086a945bb7c48d3c"
+    },
+    {
+      "path": "gulpfile.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "e10b7a3a0aa39079a98ab805d0bd55c255440634",
+      "size": 1119,
+      "url": "https://api.github.com/repos/srvance/ember-bootstrap/git/blobs/e10b7a3a0aa39079a98ab805d0bd55c255440634"
+    },
+    {
+      "path": "index.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "37dfeaea3f57bfd842819843b3c8ef64d203244b",
+      "size": 1548,
+      "url": "https://api.github.com/repos/srvance/ember-bootstrap/git/blobs/37dfeaea3f57bfd842819843b3c8ef64d203244b"
+    },
+    {
+      "path": "package.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "693d177ea0dbf6ea4c4243a99b20f67947dd94ec",
+      "size": 2400,
+      "url": "https://api.github.com/repos/srvance/ember-bootstrap/git/blobs/693d177ea0dbf6ea4c4243a99b20f67947dd94ec"
+    },
+    {
+      "path": "testem.js",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "26044b2f85947ebf574b80b9d098b17a0c95852e",
+      "size": 237,
+      "url": "https://api.github.com/repos/srvance/ember-bootstrap/git/blobs/26044b2f85947ebf574b80b9d098b17a0c95852e"
+    },
+    {
+      "path": "tests",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "fc7dea6067f4fbcceaecdf5c6c0863350fe62c3b",
+      "url": "https://api.github.com/repos/srvance/ember-bootstrap/git/trees/fc7dea6067f4fbcceaecdf5c6c0863350fe62c3b"
+    },
+    {
+      "path": "vendor",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "391940bb0e1ae45220f68829ecca022812be58ff",
+      "url": "https://api.github.com/repos/srvance/ember-bootstrap/git/trees/391940bb0e1ae45220f68829ecca022812be58ff"
+    },
+    {
+      "path": "yarn.lock",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "c2b631269339dba708adc88f050cf58c5b71e2e7",
+      "size": 241152,
+      "url": "https://api.github.com/repos/srvance/ember-bootstrap/git/blobs/c2b631269339dba708adc88f050cf58c5b71e2e7"
+    },
+    {
+      "path": "yuidoc.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "f257a6d585cbb81e26b20852c07d6731437c66a4",
+      "size": 269,
+      "url": "https://api.github.com/repos/srvance/ember-bootstrap/git/blobs/f257a6d585cbb81e26b20852c07d6731437c66a4"
+    }
+  ],
+  "truncated": false
+}
+*/

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -9,12 +9,14 @@ import OrganizationFactory from './factories/organization';
 import RepositoryFactory from './factories/repository';
 import BranchFactory from './factories/branch';
 import ReleaseFactory from './factories/release';
+import BlobFactory from './factories/blob';
 
 import './custom-helpers/assert-github-branch-ok';
 import './custom-helpers/assert-github-organization-ok';
 import './custom-helpers/assert-github-repository-ok';
 import './custom-helpers/assert-github-user-ok';
 import './custom-helpers/assert-github-release-ok';
+import './custom-helpers/assert-github-blob-ok';
 
 const { merge, run } = Ember;
 
@@ -35,6 +37,7 @@ export default function startApp(attrs) {
   RepositoryFactory.defineRepository();
   BranchFactory.defineBranch();
   ReleaseFactory.defineRelease();
+  BlobFactory.defineBlob();
 
   // Pretender doesn't work with fully qualified URLs
   GithubAdapter.reopen({

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -10,6 +10,7 @@ import RepositoryFactory from './factories/repository';
 import BranchFactory from './factories/branch';
 import ReleaseFactory from './factories/release';
 import BlobFactory from './factories/blob';
+import TreeFactory from './factories/trees';
 
 import './custom-helpers/assert-github-branch-ok';
 import './custom-helpers/assert-github-organization-ok';
@@ -17,6 +18,7 @@ import './custom-helpers/assert-github-repository-ok';
 import './custom-helpers/assert-github-user-ok';
 import './custom-helpers/assert-github-release-ok';
 import './custom-helpers/assert-github-blob-ok';
+import './custom-helpers/assert-github-tree-ok';
 
 const { merge, run } = Ember;
 
@@ -38,6 +40,7 @@ export default function startApp(attrs) {
   BranchFactory.defineBranch();
   ReleaseFactory.defineRelease();
   BlobFactory.defineBlob();
+  TreeFactory.defineTree();
 
   // Pretender doesn't work with fully qualified URLs
   GithubAdapter.reopen({

--- a/tests/unit/adapters/github-blob-test.js
+++ b/tests/unit/adapters/github-blob-test.js
@@ -1,0 +1,25 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('adapter:github-blob', 'Unit | Adapter | github blob', {
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let adapter = this.subject();
+  assert.ok(adapter);
+});
+
+test('it builds the URL correctly', function(assert) {
+  let adapter = this.subject();
+  const host = adapter.get('host');
+  const user = 'jimmay5469';
+  const repo = 'old-hash';
+  const sha = '219985c2289f78f0a652c317ec69c2bc355ee5e9';
+  let query = {
+    user,
+    repo,
+    sha
+  };
+
+  assert.equal(adapter.buildURL('github-blob', null, null, 'queryRecord', query), `${host}/repos/${user}/${repo}/git/blobs/${sha}`);
+});

--- a/tests/unit/adapters/github-blob-test.js
+++ b/tests/unit/adapters/github-blob-test.js
@@ -12,14 +12,12 @@ test('it exists', function(assert) {
 test('it builds the URL correctly', function(assert) {
   let adapter = this.subject();
   const host = adapter.get('host');
-  const user = 'jimmay5469';
-  const repo = 'old-hash';
+  const repo = 'jimmay5469/old-hash';
   const sha = '219985c2289f78f0a652c317ec69c2bc355ee5e9';
   let query = {
-    user,
     repo,
     sha
   };
 
-  assert.equal(adapter.buildURL('github-blob', null, null, 'queryRecord', query), `${host}/repos/${user}/${repo}/git/blobs/${sha}`);
+  assert.equal(adapter.buildURL('github-blob', null, null, 'queryRecord', query), `${host}/repos/${repo}/git/blobs/${sha}`);
 });

--- a/tests/unit/adapters/github-blob-test.js
+++ b/tests/unit/adapters/github-blob-test.js
@@ -1,6 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('adapter:github-blob', 'Unit | Adapter | github blob', {
+  needs: ['service:github-session']
 });
 
 // Replace this with your real tests.

--- a/tests/unit/adapters/github-branch-test.js
+++ b/tests/unit/adapters/github-branch-test.js
@@ -1,8 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('adapter:github-branch', 'Unit | Adapter | github branch', {
-  // Specify the other units that are required for this test.
-  // needs: ['serializer:foo']
+  needs: ['service:github-session']
 });
 
 test('it exists', function (assert) {

--- a/tests/unit/adapters/github-organization-test.js
+++ b/tests/unit/adapters/github-organization-test.js
@@ -1,8 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('adapter:github-organization', 'Unit | Adapter | github organization', {
-  // Specify the other units that are required for this test.
-  // needs: ['serializer:foo']
+  needs: ['service:github-session']
 });
 
 test('it exists', function (assert) {

--- a/tests/unit/adapters/github-pull-test.js
+++ b/tests/unit/adapters/github-pull-test.js
@@ -1,8 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('adapter:github-pull', 'Unit | Adapter | github pull', {
-  // Specify the other units that are required for this test.
-  // needs: ['serializer:foo']
+  needs: ['service:github-session']
 });
 
 test('it exists', function(assert) {

--- a/tests/unit/adapters/github-release-test.js
+++ b/tests/unit/adapters/github-release-test.js
@@ -1,8 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('adapter:github-release', 'Unit | Adapter | github release', {
-  // Specify the other units that are required for this test.
-  // needs: ['serializer:foo']
+  needs: ['service:github-session']
 });
 
 test('it exists', function(assert) {

--- a/tests/unit/adapters/github-repository-test.js
+++ b/tests/unit/adapters/github-repository-test.js
@@ -1,8 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('adapter:github-repository', 'Unit | Adapter | github repository', {
-  // Specify the other units that are required for this test.
-  // needs: ['serializer:foo']
+  needs: ['service:github-session']
 });
 
 test('it exists', function (assert) {

--- a/tests/unit/adapters/github-tree-test.js
+++ b/tests/unit/adapters/github-tree-test.js
@@ -1,6 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('adapter:github-tree', 'Unit | Adapter | github tree', {
+  needs: ['service:github-session']
 });
 
 test('it exists', function(assert) {
@@ -18,7 +19,7 @@ test('it builds the URL correctly', function(assert) {
     sha
   };
 
-  assert.equal(adapter.buildURL('github-blob', null, null, 'queryRecord', query), `${host}/repos/${repo}/git/trees/${sha}`);
+  assert.equal(adapter.buildURL('github-tree', null, null, 'queryRecord', query), `${host}/repos/${repo}/git/trees/${sha}`);
 });
 
 test('it builds the URL correctly with the recursive query', function(assert) {
@@ -33,6 +34,6 @@ test('it builds the URL correctly with the recursive query', function(assert) {
     recursive
   };
 
-  // NOTE: Query params are handles separately from the URL, so are not part of the expected result.
-  assert.equal(adapter.buildURL('github-blob', null, null, 'queryRecord', query), `${host}/repos/${repo}/git/trees/${sha}`);
+  // NOTE: Query params are handled separately from the URL, so are not part of the expected result.
+  assert.equal(adapter.buildURL('github-tree', null, null, 'queryRecord', query), `${host}/repos/${repo}/git/trees/${sha}`);
 });

--- a/tests/unit/adapters/github-tree-test.js
+++ b/tests/unit/adapters/github-tree-test.js
@@ -20,3 +20,19 @@ test('it builds the URL correctly', function(assert) {
 
   assert.equal(adapter.buildURL('github-blob', null, null, 'queryRecord', query), `${host}/repos/${repo}/git/trees/${sha}`);
 });
+
+test('it builds the URL correctly with the recursive query', function(assert) {
+  let adapter = this.subject();
+  const host = adapter.get('host');
+  const repo = 'jimmay5469/old-hash';
+  const sha = '219985c2289f78f0a652c317ec69c2bc355ee5e9';
+  const recursive = true;
+  let query = {
+    repo,
+    sha,
+    recursive
+  };
+
+  // NOTE: Query params are handles separately from the URL, so are not part of the expected result.
+  assert.equal(adapter.buildURL('github-blob', null, null, 'queryRecord', query), `${host}/repos/${repo}/git/trees/${sha}`);
+});

--- a/tests/unit/adapters/github-tree-test.js
+++ b/tests/unit/adapters/github-tree-test.js
@@ -1,0 +1,22 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('adapter:github-tree', 'Unit | Adapter | github tree', {
+});
+
+test('it exists', function(assert) {
+  let adapter = this.subject();
+  assert.ok(adapter);
+});
+
+test('it builds the URL correctly', function(assert) {
+  let adapter = this.subject();
+  const host = adapter.get('host');
+  const repo = 'jimmay5469/old-hash';
+  const sha = '219985c2289f78f0a652c317ec69c2bc355ee5e9';
+  let query = {
+    repo,
+    sha
+  };
+
+  assert.equal(adapter.buildURL('github-blob', null, null, 'queryRecord', query), `${host}/repos/${repo}/git/trees/${sha}`);
+});

--- a/tests/unit/adapters/github-user-test.js
+++ b/tests/unit/adapters/github-user-test.js
@@ -1,8 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('adapter:github-user', 'Unit | Adapter | github user', {
-  // Specify the other units that are required for this test.
-  // needs: ['serializer:foo']
+  needs: ['service:github-session']
 });
 
 test('it exists', function (assert) {

--- a/tests/unit/models/github-blob-test.js
+++ b/tests/unit/models/github-blob-test.js
@@ -1,0 +1,12 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('github-blob', 'Unit | Model | github blob', {
+  // Specify the other units that are required for this test.
+  needs: []
+});
+
+test('it exists', function(assert) {
+  let model = this.subject();
+  // let store = this.store();
+  assert.ok(!!model);
+});

--- a/tests/unit/models/github-tree-test.js
+++ b/tests/unit/models/github-tree-test.js
@@ -1,0 +1,12 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('github-tree', 'Unit | Model | github tree', {
+  // Specify the other units that are required for this test.
+  needs: ['model:github-blob']
+});
+
+test('it exists', function(assert) {
+  let model = this.subject();
+  // let store = this.store();
+  assert.ok(!!model);
+});

--- a/tests/unit/serializers/github-blob-test.js
+++ b/tests/unit/serializers/github-blob-test.js
@@ -1,0 +1,15 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('github-blob', 'Unit | Serializer | github blob', {
+  // Specify the other units that are required for this test.
+  needs: ['serializer:github-blob']
+});
+
+// Replace this with your real tests.
+test('it serializes records', function(assert) {
+  let record = this.subject();
+
+  let serializedRecord = record.serialize();
+
+  assert.ok(serializedRecord);
+});

--- a/tests/unit/serializers/github-tree-test.js
+++ b/tests/unit/serializers/github-tree-test.js
@@ -1,0 +1,15 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('github-tree', 'Unit | Serializer | github tree', {
+  // Specify the other units that are required for this test.
+  needs: ['serializer:github-tree', 'model:github-blob']
+});
+
+// Replace this with your real tests.
+test('it serializes records', function(assert) {
+  let record = this.subject();
+
+  let serializedRecord = record.serialize();
+
+  assert.ok(serializedRecord);
+});


### PR DESCRIPTION
@elwayman02 Do you know of a better way to handle the tree entries? The `path` names are part of the tree, not part of the referenced `tree` or `blob`. I suspect this allows a single hash to appear in multiple directories or for the hash to remain the same if the file is renamed or moved. The result is that you have a referenced entity that is a superset of the entity's direct representation.