### PR TITLE
Support fetching resources by id

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,10 @@ export default GitHubUserAdapter.extend(DataAdapterMixin, {
 The following examples show how to retrieve each supported GitHub entity as you might use it in your `model` hook.
 ```js
 this.get('store').findRecord('github-user', '#'); // get the current user
-this.get('store').findRecord('github-user', 'jimmay5469'); // get a user
-this.get('store').findRecord('github-repository', 'jimmay5469/old-hash'); // get a repository
+this.get('store').findRecord('github-user', 'jimmay5469'); // get a user by user login
+this.get('store').findRecord('github-user', 917672); // get a user by user id
+this.get('store').findRecord('github-repository', 'jimmay5469/old-hash'); // get a repository by repository name
+this.get('store').findRecord('github-repository', 34598603); // get a repository by repository id
 this.get('store').findRecord('github-branch', 'jimmay5469/old-hash/branches/master'); // get a branch
 this.get('store').queryRecord('github-branch', { repo: 'jimmay5469/old-hash', branch: 'master' }); // get a specific branch
 this.get('store').query('github-branch', { repo: 'jimmay5469/old-hash' }); // get a repo's branches

--- a/addon/adapters/github-repository.js
+++ b/addon/adapters/github-repository.js
@@ -3,11 +3,9 @@ import GithubAdapter from './github';
 export default GithubAdapter.extend({
   urlForFindRecord(id, modelName, snapshot) {
     let builtURL = this._super(id, modelName, snapshot);
-
     if (Number.isInteger(id) === false) {
       builtURL = builtURL.replace('repositories', 'repos')
     }
-
     return builtURL.replace('%2F', '/');
   }
 });

--- a/addon/adapters/github-repository.js
+++ b/addon/adapters/github-repository.js
@@ -2,8 +2,12 @@ import GithubAdapter from './github';
 
 export default GithubAdapter.extend({
   urlForFindRecord(id, modelName, snapshot) {
-    return this._super(id, modelName, snapshot)
-      .replace('repositories', 'repos')
-      .replace('%2F', '/');
+    let builtURL = this._super(id, modelName, snapshot);
+
+    if (Number.isInteger(id) === false) {
+      builtURL = builtURL.replace('repositories', 'repos')
+    }
+
+    return builtURL.replace('%2F', '/');
   }
 });

--- a/addon/adapters/github-repository.js
+++ b/addon/adapters/github-repository.js
@@ -2,8 +2,9 @@ import GithubAdapter from './github';
 
 export default GithubAdapter.extend({
   urlForFindRecord(id, modelName, snapshot) {
+    const isInteger = /^\d+$/;
     let builtURL = this._super(id, modelName, snapshot);
-    if (Number.isInteger(id) === false) {
+    if (!isInteger.test(id)) {
       builtURL = builtURL.replace('repositories', 'repos')
     }
     return builtURL.replace('%2F', '/');

--- a/addon/adapters/github-user.js
+++ b/addon/adapters/github-user.js
@@ -5,6 +5,8 @@ export default GithubAdapter.extend({
     let builtURL = this._super(id, modelName, snapshot);
     if (id === '#') {
       builtURL = builtURL.replace('users/%23', 'user');
+    } else if (Number.isInteger(id)) {
+      builtURL = builtURL.replace('/users/', '/user/')
     }
     return builtURL;
   }

--- a/addon/adapters/github-user.js
+++ b/addon/adapters/github-user.js
@@ -2,10 +2,11 @@ import GithubAdapter from './github';
 
 export default GithubAdapter.extend({
   urlForFindRecord(id, modelName, snapshot) {
+    const isInteger = /^\d+$/;
     let builtURL = this._super(id, modelName, snapshot);
     if (id === '#') {
       builtURL = builtURL.replace('users/%23', 'user');
-    } else if (Number.isInteger(id)) {
+    } else if (isInteger.test(id)) {
       builtURL = builtURL.replace('/users/', '/user/')
     }
     return builtURL;

--- a/tests/acceptance/github-repository-test.js
+++ b/tests/acceptance/github-repository-test.js
@@ -39,7 +39,7 @@ test('finding a repository without authorization', function (assert) {
   });
 });
 
-test('finding a repository', function (assert) {
+test('finding a repository by name', function (assert) {
   assert.expect(4);
 
   container.lookup('service:github-session').set('githubAccessToken', 'abc123');
@@ -56,6 +56,25 @@ test('finding a repository', function (assert) {
     });
   });
 });
+
+test('finding a repository by id', function (assert) {
+  assert.expect(4);
+
+  container.lookup('service:github-session').set('githubAccessToken', 'abc123');
+  server.get('/repositories/1', () => {
+    return [200, {}, Factory.build('repository')];
+  });
+
+  return run(() => {
+    return store.findRecord('githubRepository', 1).then((repository) => {
+      assert.githubRepositoryOk(repository);
+      assert.equal(store.peekAll('githubRepository').get('length'), 1, 'loads 1 repository');
+      assert.equal(server.handledRequests.length, 1, 'handles 1 request');
+      assert.equal(server.handledRequests[0].requestHeaders.Authorization, 'token abc123', 'has the authorization token');
+    });
+  });
+});
+
 
 test('finding all repositories', function (assert) {
   assert.expect(4);

--- a/tests/acceptance/github-user-test.js
+++ b/tests/acceptance/github-user-test.js
@@ -55,7 +55,7 @@ test('finding a user by login', function (assert) {
 
 test('finding a user by id', function (assert) {
   container.lookup('service:github-session').set('githubAccessToken', 'abc123');
-  server.get('/users/1', () => {
+  server.get('/user/1', () => {
     return [200, {}, Factory.build('user')];
   });
 

--- a/tests/acceptance/github-user-test.js
+++ b/tests/acceptance/github-user-test.js
@@ -37,7 +37,7 @@ test('finding a user without authorization', function (assert) {
   });
 });
 
-test('finding a user', function (assert) {
+test('finding a user by login', function (assert) {
   container.lookup('service:github-session').set('githubAccessToken', 'abc123');
   server.get('/users/user1', () => {
     return [200, {}, Factory.build('user')];
@@ -45,6 +45,22 @@ test('finding a user', function (assert) {
 
   return run(() => {
     return store.findRecord('githubUser', 'user1').then((user) => {
+      assert.githubUserOk(user);
+      assert.equal(store.peekAll('githubUser').get('length'), 1);
+      assert.equal(server.handledRequests.length, 1);
+      assert.equal(server.handledRequests[0].requestHeaders.Authorization, 'token abc123');
+    });
+  });
+});
+
+test('finding a user by id', function (assert) {
+  container.lookup('service:github-session').set('githubAccessToken', 'abc123');
+  server.get('/users/1', () => {
+    return [200, {}, Factory.build('user')];
+  });
+
+  return run(() => {
+    return store.findRecord('githubUser', 1).then((user) => {
       assert.githubUserOk(user);
       assert.equal(store.peekAll('githubUser').get('length'), 1);
       assert.equal(server.handledRequests.length, 1);

--- a/tests/unit/adapters/github-repository-test.js
+++ b/tests/unit/adapters/github-repository-test.js
@@ -19,15 +19,16 @@ test('it builds the index URL correctly', function(assert) {
 test('it builds the specified repo name URL correctly', function(assert) {
   let adapter = this.subject();
   const host = adapter.get('host');
+  const name = 'elwayman02/ember-data-github';
 
-  const repo = 'elwayman02/ember-data-github';
-  assert.equal(adapter.buildURL('github-repository', repo, null, 'findRecord'), `${host}/repos/${repo}`);
+  assert.equal(adapter.buildURL('github-repository', name, null, 'findRecord'), `${host}/repos/${name}`);
 });
 
 test('it builds the specified repo id URL correctly', function(assert) {
   let adapter = this.subject();
   const host = adapter.get('host');
+  const id = 34598603;
 
-  const repo = 34598603;
-  assert.equal(adapter.buildURL('github-repository', repo, null, 'findRecord'), `${host}/repositories/${repo}`);
+  assert.equal(adapter.buildURL('github-repository', parseInt(id), null, 'findRecord'), `${host}/repositories/${id}`);
+  assert.equal(adapter.buildURL('github-repository', id.toString(), null, 'findRecord'), `${host}/repositories/${id}`);
 });

--- a/tests/unit/adapters/github-repository-test.js
+++ b/tests/unit/adapters/github-repository-test.js
@@ -16,10 +16,18 @@ test('it builds the index URL correctly', function(assert) {
   assert.equal(adapter.buildURL('github-repository', null, null), `${host}/repositories`);
 });
 
-test('it builds the specified repo URL correctly', function(assert) {
+test('it builds the specified repo name URL correctly', function(assert) {
   let adapter = this.subject();
   const host = adapter.get('host');
 
   const repo = 'elwayman02/ember-data-github';
   assert.equal(adapter.buildURL('github-repository', repo, null, 'findRecord'), `${host}/repos/${repo}`);
+});
+
+test('it builds the specified repo id URL correctly', function(assert) {
+  let adapter = this.subject();
+  const host = adapter.get('host');
+
+  const repo = 34598603;
+  assert.equal(adapter.buildURL('github-repository', repo, null, 'findRecord'), `${host}/repositories/${repo}`);
 });

--- a/tests/unit/adapters/github-user-test.js
+++ b/tests/unit/adapters/github-user-test.js
@@ -19,15 +19,16 @@ test('it builds the current user URL correctly', function(assert) {
 test('it builds specified user login URLs correctly', function(assert) {
   let adapter = this.subject();
   const host = adapter.get('host');
-  const user = 'elwayman02';
+  const login = 'elwayman02';
 
-  assert.equal(adapter.buildURL('github-user', user, null, 'findRecord'), `${host}/users/${user}`);
+  assert.equal(adapter.buildURL('github-user', login, null, 'findRecord'), `${host}/users/${login}`);
 });
 
 test('it builds specified user id URLs correctly', function(assert) {
   let adapter = this.subject();
   const host = adapter.get('host');
-  const user = 917672;
+  const id = 917672;
 
-  assert.equal(adapter.buildURL('github-user', user, null, 'findRecord'), `${host}/user/${user}`);
+  assert.equal(adapter.buildURL('github-user', parseInt(id), null, 'findRecord'), `${host}/user/${id}`);
+  assert.equal(adapter.buildURL('github-user', id.toString(), null, 'findRecord'), `${host}/user/${id}`);
 });

--- a/tests/unit/adapters/github-user-test.js
+++ b/tests/unit/adapters/github-user-test.js
@@ -16,10 +16,18 @@ test('it builds the current user URL correctly', function(assert) {
   assert.equal(adapter.buildURL('github-user', '#', null, 'findRecord'), `${host}/user`);
 });
 
-test('it builds specified user URLs correctly', function(assert) {
+test('it builds specified user login URLs correctly', function(assert) {
   let adapter = this.subject();
   const host = adapter.get('host');
   const user = 'elwayman02';
 
   assert.equal(adapter.buildURL('github-user', user, null, 'findRecord'), `${host}/users/${user}`);
+});
+
+test('it builds specified user id URLs correctly', function(assert) {
+  let adapter = this.subject();
+  const host = adapter.get('host');
+  const user = 917672;
+
+  assert.equal(adapter.buildURL('github-user', user, null, 'findRecord'), `${host}/user/${user}`);
 });


### PR DESCRIPTION
Currently, this addon doesn't accommodate fetching `github-user` or `github-repository` by it's id. That's because GitHub has an unusual API that requires using a different URL depending on whether you are fetching by name or id.

For example, this fails:

```
GET https://api.github.com/users/917672

{
  "message": "Not Found",
  "documentation_url": "https://developer.github.com/v3/users/#get-a-single-user"
}
```

But this works:

```
GET https://api.github.com/user/917672

{
  "login": "joshwlewis",
  "id": 917672,
  "avatar_url": "https://avatars1.githubusercontent.com/u/917672?v=4",
  "gravatar_id": "",
  "url": "https://api.github.com/users/joshwlewis",
  "html_url": "https://github.com/joshwlewis",
  "followers_url": "https://api.github.com/users/joshwlewis/followers",
  "following_url": "https://api.github.com/users/joshwlewis/following{/other_user}",
  "gists_url": "https://api.github.com/users/joshwlewis/gists{/gist_id}",
  "starred_url": "https://api.github.com/users/joshwlewis/starred{/owner}{/repo}",
  "subscriptions_url": "https://api.github.com/users/joshwlewis/subscriptions",
  "organizations_url": "https://api.github.com/users/joshwlewis/orgs",
  "repos_url": "https://api.github.com/users/joshwlewis/repos",
  "events_url": "https://api.github.com/users/joshwlewis/events{/privacy}",
  "received_events_url": "https://api.github.com/users/joshwlewis/received_events",
  "type": "User",
  "site_admin": false,
  "name": "Josh W Lewis",
  "company": "Heroku",
  "blog": "http://joshwlewis.com",
  "location": "Memphis, TN",
  "email": null,
  "hireable": null,
  "bio": null,
  "public_repos": 68,
  "public_gists": 7,
  "followers": 57,
  "following": 51,
  "created_at": "2011-07-15T13:16:41Z",
  "updated_at": "2017-10-02T16:34:22Z"
}
```

This PR adds support for fetching by id, by detecting if the provided id is an integer.

It is possible to name both resources with digits on GitHub, so this means there is a potential conflict if you want to find the user with the login `"1234"`, but instead get the user with id `1234`. This PR means we would prefer the id version, and I believe that's consistent with the way EmberData is designed (heavily based on remote ids).