### PR TITLE
add tests for github-pull

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ this.get('store').queryRecord('github-branch', { repo: 'jimmay5469/old-hash', br
 this.get('store').query('github-branch', { repo: 'jimmay5469/old-hash' }); // get a repo's branches
 this.get('store').queryRecord('github-release', { repo: 'jimmay5469/old-hash', releaseId: 1 }); // get a specific release
 this.get('store').query('github-release', { repo: 'jimmay5469/old-hash' }); // get a repo's releases
+this.get('store').queryRecord('github-pull', { repo: 'jimmay5469/old-hash', pullId: 1 }); // get a specific pull request
+this.get('store').query('github-pull', { repo: 'jimmay5469/old-hash' }); // get a repo's pull requests
 this.get('store').queryRecord('github-blob', { repo: 'jimmay5469/old-hash', sha: '47c5438403ca875f170db2aa07d1bfa3689406e3' }); // get a file's contents
 ```
 

--- a/addon/adapters/github-pull.js
+++ b/addon/adapters/github-pull.js
@@ -1,4 +1,18 @@
 import GithubAdapter from './github';
 
 export default GithubAdapter.extend({
+  urlForQuery(query) {
+    const repo = query.repo;
+    delete query.repo;
+    return `${this.get('host')}/repos/${repo}/pulls`;
+  },
+
+  urlForQueryRecord(query) {
+    const repo = query.repo;
+    const pullId = query.pullId;
+    delete query.repo;
+    delete query.pullId;
+
+    return `${this.get('host')}/repos/${repo}/pulls/${pullId}`;
+  }
 });

--- a/tests/acceptance/github-repository-test.js
+++ b/tests/acceptance/github-repository-test.js
@@ -141,3 +141,22 @@ test('finding a repository\'s releases', function (assert) {
     });
   });
 });
+
+test('finding a repository\'s pull requests', function (assert) {
+  assert.expect(4);
+
+  let owner = server.create('github-user');
+  server.create('github-repository', { owner }, 'withPulls');
+  container.lookup('service:github-session').set('githubAccessToken', 'abc123');
+
+  return run(() => {
+    return store.findRecord('githubRepository', 'user1/repository1').then((repository) => {
+      return repository.get('pulls').then(function (pulls) {
+        assert.equal(pulls.get('length'), 2, 'loads 2 pull requests');
+        assert.githubPullOk(pulls.toArray()[0]);
+        assert.equal(server.pretender.handledRequests.length, 2, 'handles 2 requests');
+        assert.equal(server.pretender.handledRequests[1].requestHeaders.Authorization, 'token abc123', 'has the authorization token');
+      });
+    });
+  });
+});

--- a/tests/acceptance/gitub-pull-test.js
+++ b/tests/acceptance/gitub-pull-test.js
@@ -1,0 +1,78 @@
+import { run } from '@ember/runloop';
+import { test } from 'qunit';
+import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
+
+let container, store;
+
+moduleForAcceptance('Acceptance | github pull', {
+  beforeEach() {
+    container = this.application.__container__;
+    store = run(container, 'lookup', 'service:store');
+  }
+});
+
+test('finding a pull request without authorization', function (assert) {
+  assert.expect(4);
+
+  server.create('github-pull');
+
+  return run(() => {
+    return store.queryRecord('githubPull', { repo: 'user1/repository1', pullId: '1' }).then((pull) => {
+      assert.githubPullOk(pull);
+      assert.equal(store.peekAll('githubPull').get('length'), 1, 'loads 1 pull');
+      assert.equal(server.pretender.handledRequests.length, 1, 'handles 1 request');
+      assert.equal(server.pretender.handledRequests[0].requestHeaders.Authorization, undefined, 'has no authorization token');
+    });
+  });
+});
+
+test('finding a pull request', function (assert) {
+  assert.expect(4);
+
+  container.lookup('service:github-session').set('githubAccessToken', 'abc123');
+  server.create('github-pull');
+
+  return run(() => {
+    return store.queryRecord('githubPull', { repo: 'user1/repository0', pullId: '1' }).then((pull) => {
+      assert.githubPullOk(pull);
+      assert.equal(store.peekAll('githubPull').get('length'), 1, 'loads 1 pull');
+      assert.equal(server.pretender.handledRequests.length, 1, 'handles 1 request');
+      assert.equal(server.pretender.handledRequests[0].requestHeaders.Authorization, 'token abc123', 'has the authorization token');
+    });
+  });
+});
+
+test('finding all pull requests', function (assert) {
+  assert.expect(4);
+
+  container.lookup('service:github-session').set('githubAccessToken', 'abc123');
+  let repository = server.create('githubRepository');
+  server.createList('github-pull', 2, { repository });
+
+  return run(() => {
+    return store.query('githubPull', { repo: 'user1/repository0' }).then((pulls) => {
+      assert.githubPullOk(pulls.toArray()[0]);
+      assert.equal(store.peekAll('githubPull').get('length'), 2, 'loads 2 pulls');
+      assert.equal(server.pretender.handledRequests.length, 1, 'handles 1 request');
+      assert.equal(server.pretender.handledRequests[0].requestHeaders.Authorization, 'token abc123', 'has the authorization token');
+    });
+  });
+});
+
+test('getting a pull request\'s author', function (assert) {
+  assert.expect(4);
+
+  container.lookup('service:github-session').set('githubAccessToken', 'abc123');
+  server.create('github-pull');
+
+  return run(() => {
+    return store.queryRecord('githubPull', { repo: 'user1/repository0', pullId: '1' }).then((pull) => {
+      return pull.get('user').then(function (user) {
+        assert.githubUserOk(user);
+        assert.equal(store.peekAll('githubUser').get('length'), 1, 'loads 1 user');
+        assert.equal(server.pretender.handledRequests.length, 2, 'handles 2 requests');
+        assert.equal(server.pretender.handledRequests[0].requestHeaders.Authorization, 'token abc123', 'has the authorization token');
+      });
+    });
+  });
+});

--- a/tests/dummy/mirage/config.js
+++ b/tests/dummy/mirage/config.js
@@ -61,6 +61,14 @@ export default function() {
     return schema.githubRepositories.findBy({ name: params.repo }).releases;
   });
 
+  this.get('repos/:user/:repo/pulls', (schema, { params }) => {
+    return schema.githubRepositories.findBy({ name: params.repo }).pulls;
+  });
+
+  this.get('repos/:user/:repo/pulls/:pull', (schema, { params }) => {
+    return schema.githubPulls.findBy({ id: params.pull });
+  });
+
   this.get('repos/:user/:repo/git/trees/:tree', (schema, { params }) => {
     return schema.githubTrees.findBy({ id: params.tree });
   });

--- a/tests/dummy/mirage/factories/github-pull.js
+++ b/tests/dummy/mirage/factories/github-pull.js
@@ -1,4 +1,19 @@
-import { Factory } from 'ember-cli-mirage';
+import { Factory, faker } from 'ember-cli-mirage';
 
 export default Factory.extend({
+  number: faker.random.number(),
+  title: faker.lorem.words(),
+  state: 'open',
+  html_url: function(i) {
+    return `https://github.com/octocat/Hello-World/pull/${i}`;
+  },
+  body: faker.lorem.words(),
+  created_at: faker.date.past(),
+  updated_at: faker.date.past(),
+  closed_at: faker.date.past(),
+  merged_at: faker.date.past(),
+
+  afterCreate(pull, server) {
+    pull.update('user', server.create('github-user'));
+  }
 });

--- a/tests/dummy/mirage/factories/github-repository.js
+++ b/tests/dummy/mirage/factories/github-repository.js
@@ -40,5 +40,11 @@ export default Factory.extend({
     afterCreate(repository) {
       server.createList('githubRelease', 2, { repository });
     }
+  }),
+
+  withPulls: trait({
+    afterCreate(repository) {
+      server.createList('githubPull', 2, { repository });
+    }
   })
 });

--- a/tests/dummy/mirage/models/github-pull.js
+++ b/tests/dummy/mirage/models/github-pull.js
@@ -1,0 +1,6 @@
+import { Model, belongsTo } from 'ember-cli-mirage';
+
+export default Model.extend({
+  repository: belongsTo('githubRepository'),
+  user: belongsTo('githubUser')
+});

--- a/tests/dummy/mirage/serializers/github-pull.js
+++ b/tests/dummy/mirage/serializers/github-pull.js
@@ -1,0 +1,5 @@
+import ApplicationSerializer from './application';
+
+export default ApplicationSerializer.extend({
+  include: ['user']
+});

--- a/tests/helpers/custom-helpers/assert-github-pull-ok.js
+++ b/tests/helpers/custom-helpers/assert-github-pull-ok.js
@@ -1,0 +1,25 @@
+import { registerHelper } from '@ember/test';
+import QUnit from 'qunit';
+import assertionBuilder from '../utils/defined-attribute-assertion-builder';
+
+QUnit.assert.githubPullOk = assertionBuilder([
+  'id',
+  'number',
+  'title',
+  'state',
+  'htmlUrl',
+  'body',
+  'createdAt',
+  'updatedAt',
+  'closedAt',
+  'mergedAt',
+  'userLogin',
+  'userAvatarUrl'
+]);
+
+export default registerHelper(
+  'githubPullOk',
+  function (app, assert, release) {
+    assert.githubPullOk(release);
+  }
+);

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -10,6 +10,7 @@ import './custom-helpers/assert-github-user-ok';
 import './custom-helpers/assert-github-release-ok';
 import './custom-helpers/assert-github-blob-ok';
 import './custom-helpers/assert-github-tree-ok';
+import './custom-helpers/assert-github-pull-ok';
 
 export default function startApp(attrs) {
   let attributes = merge({}, config.APP);


### PR DESCRIPTION
Closes https://github.com/elwayman02/ember-data-github/issues/115

Note that technically this is a breaking change but I'm not sure that looking up pull requests would have worked before.  The way the adapter was setup would create a request like this which is not actually valid:

`https://api.github.com/pulls?pullId=1&repo=user1%2Frepository1`

Now it will do:

`https://api.github.com/repos/user1/repository1/pulls/1`