### PR TITLE
remove github from relation property names

### DIFF
--- a/addon/models/github-organization.js
+++ b/addon/models/github-organization.js
@@ -4,6 +4,6 @@ export default DS.Model.extend({
   login: DS.attr('string'),
   name: DS.attr('string'),
   avatarUrl: DS.attr('string'),
-  githubUsers: DS.hasMany('githubUser', { async: true }),
-  githubRepositories: DS.hasMany('githubRepository', { async: true })
+  users: DS.hasMany('githubUser', { async: true }),
+  repositories: DS.hasMany('githubRepository', { async: true })
 });

--- a/addon/models/github-user.js
+++ b/addon/models/github-user.js
@@ -18,5 +18,5 @@ export default DS.Model.extend({
   location: DS.attr('string'),
   email: DS.attr('string'),
   bio: DS.attr('string'),
-  githubRepositories: DS.hasMany('githubRepository', { async: true })
+  repositories: DS.hasMany('githubRepository', { async: true })
 });

--- a/addon/serializers/github-organization.js
+++ b/addon/serializers/github-organization.js
@@ -8,8 +8,8 @@ export default GithubSerializer.extend({
       name: hash.name,
       avatarUrl: hash.avatar_url,
       links: {
-        githubUsers: hash.members_url.replace(/\{\/member\}/, ''),
-        githubRepositories: hash.repos_url
+        users: hash.members_url.replace(/\{\/member\}/, ''),
+        repositories: hash.repos_url
       }
     };
     return this._super(type, hash, prop);

--- a/addon/serializers/github-user.js
+++ b/addon/serializers/github-user.js
@@ -29,7 +29,7 @@ export default GithubSerializer.extend({
       email: resourceHash.email,
       bio: resourceHash.bio,
       links: {
-        githubRepositories: resourceHash.repos_url
+        repositories: resourceHash.repos_url
       }
     };
     return this._super(modelClass, normalizedHash, prop);

--- a/tests/acceptance/current-github-user-test.js
+++ b/tests/acceptance/current-github-user-test.js
@@ -28,10 +28,10 @@ test('finding current user', function (assert) {
 
 test(`finding current user's repositories`, function (assert) {
   assert.expect(4);
-  
+
   return run(() => {
     return store.findRecord('githubUser', '#').then((user) => {
-      return user.get('githubRepositories').then((repositories) => {
+      return user.get('repositories').then((repositories) => {
         assert.equal(repositories.get('length'), 2);
         assert.githubRepositoryOk(repositories.toArray()[0]);
         assert.equal(server.pretender.handledRequests.length, 2);

--- a/tests/acceptance/github-organization-test.js
+++ b/tests/acceptance/github-organization-test.js
@@ -49,7 +49,7 @@ test(`finding an organization's repositories`, function (assert) {
 
   return run(() => {
     return store.findRecord('githubOrganization', 'organization0').then((organization) => {
-      return organization.get('githubRepositories').then(function (repositories) {
+      return organization.get('repositories').then(function (repositories) {
         assert.equal(repositories.get('length'), 2);
         assert.githubRepositoryOk(repositories.toArray()[0]);
         assert.equal(server.pretender.handledRequests.length, 2);

--- a/tests/acceptance/github-user-test.js
+++ b/tests/acceptance/github-user-test.js
@@ -82,7 +82,7 @@ test(`finding a user's repositories`, function (assert) {
 
   return run(() => {
     return store.findRecord('githubUser', 'user1').then((user) => {
-      return user.get('githubRepositories').then((repositories) => {
+      return user.get('repositories').then((repositories) => {
         assert.equal(repositories.get('length'), 2);
         assert.githubRepositoryOk(repositories.toArray()[0]);
         assert.equal(server.pretender.handledRequests.length, 2);

--- a/tests/dummy/mirage/config.js
+++ b/tests/dummy/mirage/config.js
@@ -78,6 +78,6 @@ export default function() {
   });
 
   this.get('orgs/:org/repos', (schema, { params }) => {
-    return schema.githubOrganizations.findBy({ login: params.org }).githubRepositories;
+    return schema.githubOrganizations.findBy({ login: params.org }).repositories;
   });
 }

--- a/tests/dummy/mirage/models/github-organization.js
+++ b/tests/dummy/mirage/models/github-organization.js
@@ -1,6 +1,6 @@
 import { Model, hasMany } from 'ember-cli-mirage';
 
 export default Model.extend({
-  githubUsers: hasMany('githubUser'),
-  githubRepositories: hasMany('githubRepository')
+  users: hasMany('githubUser'),
+  repositories: hasMany('githubRepository')
 });


### PR DESCRIPTION
Fixes https://github.com/elwayman02/ember-data-github/issues/114

Since we are pre-1.0 I think this could be released in a new minor version with a release note calling out the change, but I'm open to other ideas.