### PR TITLE
Add github-compare

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,14 @@ this.get('store').query('github-release', { repo: 'jimmay5469/old-hash' });
 this.get('store').queryRecord('github-release', { repo: 'jimmay5469/old-hash', releaseId: 1 });
 ```
 
+##### [Commits](https://developer.github.com/v3/repos/commits/)
+
+###### [Compate two commits](https://developer.github.com/v3/repos/commits/#compare-two-commits)
+
+```js
+this.get('store').queryRecord('github-compare', { repo: 'jimmay5469/old-hash', base: '1234', head: '5678' });
+```
+
 #### [Pull Requests](https://developer.github.com/v3/pulls/)
 
 ##### [List pull requests](https://developer.github.com/v3/pulls/#list-pull-requests)

--- a/addon/adapters/github-compare.js
+++ b/addon/adapters/github-compare.js
@@ -1,0 +1,12 @@
+import GithubAdapter from 'ember-data-github/adapters/github';
+
+export default GithubAdapter.extend({
+  urlForQueryRecord(query) {
+    const { repo, base, head } = query;
+    delete query.repo;
+    delete query.base;
+    delete query.head;
+
+    return `${this.get('host')}/repos/${repo}/compare/${base}...${head}`;
+  }
+});

--- a/addon/models/github-commit.js
+++ b/addon/models/github-commit.js
@@ -1,0 +1,11 @@
+import Model from 'ember-data/model';
+import attr from 'ember-data/attr';
+
+export default Model.extend({
+  sha: attr('string'),
+  url: attr('string'),
+  parents: attr(),
+  commit: attr(),
+  author: attr(),
+  committer: attr()
+});

--- a/addon/models/github-compare.js
+++ b/addon/models/github-compare.js
@@ -1,0 +1,19 @@
+import Model from 'ember-data/model';
+import attr from 'ember-data/attr';
+import { belongsTo, hasMany } from 'ember-data/relationships';
+
+export default Model.extend({
+  aheadBy: attr('number'),
+  behindBy: attr('number'),
+  status: attr('string'),
+  totalCommits: attr('number'),
+  diffUrl: attr('string'),
+  htmlUrl: attr('string'),
+  patchUrl: attr('string'),
+  permalinkUrl: attr('string'),
+
+  baseCommit: belongsTo('github-commit'),
+  mergeBaseCommit: belongsTo('github-commit'),
+  commits: hasMany('github-commit'),
+  files: hasMany('github-file')
+});

--- a/addon/models/github-file.js
+++ b/addon/models/github-file.js
@@ -1,0 +1,14 @@
+import Model from 'ember-data/model';
+import attr from 'ember-data/attr';
+
+export default Model.extend({
+  additions: attr('number'),
+  blobUrl: attr('string'),
+  changes: attr('number'),
+  deletions: attr('number'),
+  filename: attr('string'),
+  patch: attr('string'),
+  rawUrl: attr('string'),
+  sha: attr('string'),
+  status: attr('string')
+});

--- a/addon/serializers/github-compare.js
+++ b/addon/serializers/github-compare.js
@@ -1,0 +1,39 @@
+import DS from 'ember-data';
+import GithubSerializer from 'ember-data-github/serializers/github';
+
+const { EmbeddedRecordsMixin } = DS;
+
+export default GithubSerializer.extend(EmbeddedRecordsMixin, {
+  attrs: {
+    commits: { embedded: 'always' },
+    files: { embedded: 'always' },
+    baseCommit: { embedded: 'always' },
+    mergeBaseCommit: { embedded: 'always' }
+  },
+
+  normalize(modelClass, resourceHash, prop) {
+    resourceHash.id = resourceHash.diff_url;
+
+    return this._super(modelClass, resourceHash, prop);
+  },
+
+  extractRelationships(modelClass, resourceHash) {
+    resourceHash.base_commit.type = 'github-commit';
+    resourceHash.base_commit.id = resourceHash['base_commit']['sha'];
+
+    resourceHash.merge_base_commit.type = 'github-commit';
+    resourceHash.merge_base_commit.id = resourceHash['merge_base_commit']['sha'];
+
+    resourceHash.commits.forEach((commit) => {
+      commit.type = 'github-commit';
+      commit.id = commit.sha;
+    });
+
+    resourceHash.files.forEach((file) => {
+      file.type = 'github-file';
+      file.id = file.sha;
+    });
+
+    return this._super(modelClass, resourceHash);
+  }
+});

--- a/app/adapters/github-compare.js
+++ b/app/adapters/github-compare.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-github/adapters/github-compare';

--- a/app/mirage-factories/github-commit.js
+++ b/app/mirage-factories/github-commit.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-github/mirage-factories/github-commit';

--- a/app/mirage-factories/github-compare.js
+++ b/app/mirage-factories/github-compare.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-github/mirage-factories/github-compare';

--- a/app/mirage-factories/github-file.js
+++ b/app/mirage-factories/github-file.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-github/mirage-factories/github-file';

--- a/app/mirage-models/github-commit.js
+++ b/app/mirage-models/github-commit.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-github/mirage-models/github-commit';

--- a/app/mirage-models/github-compare.js
+++ b/app/mirage-models/github-compare.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-github/mirage-models/github-compare';

--- a/app/mirage-models/github-file.js
+++ b/app/mirage-models/github-file.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-github/mirage-models/github-file';

--- a/app/models/github-commit.js
+++ b/app/models/github-commit.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-github/models/github-commit';

--- a/app/models/github-compare.js
+++ b/app/models/github-compare.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-github/models/github-compare';

--- a/app/models/github-file.js
+++ b/app/models/github-file.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-github/models/github-file';

--- a/app/serializers/github-compare.js
+++ b/app/serializers/github-compare.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-github/serializers/github-compare';

--- a/tests/acceptance/github-compare-test.js
+++ b/tests/acceptance/github-compare-test.js
@@ -1,0 +1,41 @@
+import { run } from '@ember/runloop';
+import { test } from 'qunit';
+import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
+
+let container, store;
+
+moduleForAcceptance('Acceptance | github compare', {
+  beforeEach() {
+    container = this.application.__container__;
+    store = run(container, 'lookup', 'service:store');
+  }
+});
+
+test('finding a comparison without authorization', function (assert) {
+  assert.expect(3);
+
+  server.create('github-compare');
+
+  return run(() => {
+    return store.queryRecord('githubCompare', { repo: 'user1/repository1', base: '1234', 'head': '1234' }).then((compare) => {
+      assert.githubCompareOk(compare);
+      assert.equal(store.peekAll('githubCompare').get('length'), 1, 'loads 1 compare');
+      assert.equal(server.pretender.handledRequests[0].requestHeaders.Authorization, undefined, 'has no authorization token');
+    });
+  });
+});
+
+test('finding a comparison', function (assert) {
+  assert.expect(3);
+
+  server.create('github-compare');
+  container.lookup('service:github-session').set('githubAccessToken', 'abc123');
+
+  return run(() => {
+    return store.queryRecord('githubCompare', { repo: 'user1/repository1', base: '1234', 'head': '1234' }).then((compare) => {
+      assert.githubCompareOk(compare);
+      assert.equal(store.peekAll('githubCompare').get('length'), 1, 'loads 1 compare');
+      assert.equal(server.pretender.handledRequests[0].requestHeaders.Authorization, 'token abc123');
+    });
+  });
+});

--- a/tests/dummy/mirage/config.js
+++ b/tests/dummy/mirage/config.js
@@ -73,6 +73,10 @@ export default function testConfig() {
     return schema.githubTrees.findBy({ id: params.tree });
   });
 
+  this.get('repos/:user/:repo/compare/:base...:head', (schema) => {
+    return schema.githubCompares.first();
+  });
+
   this.get('/orgs/:org', (schema, { params }) => {
     return schema.githubOrganizations.findBy({ login: params.org });
   });

--- a/tests/dummy/mirage/factories/github-commit.js
+++ b/tests/dummy/mirage/factories/github-commit.js
@@ -1,0 +1,14 @@
+import { Factory, faker } from 'ember-cli-mirage';
+
+export default Factory.extend({
+  id() {
+    return this.sha;
+  },
+  sha: function(i) {
+    return `${i}51a87a3027a3ab2asfsfb23dd24186dfd7d587`
+  },
+  commit: {
+    message: faker.random.words()
+  },
+  url: 'https://api.github.com/repos/octocat/Hello-World/git/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e'
+});

--- a/tests/dummy/mirage/factories/github-compare.js
+++ b/tests/dummy/mirage/factories/github-compare.js
@@ -1,0 +1,21 @@
+import { Factory, faker } from 'ember-cli-mirage';
+
+export default Factory.extend({
+  ahead_by: faker.random.number(),
+  behind_by: faker.random.number(),
+  status: 'behind',
+  total_commits: faker.random.number(),
+  diff_url: 'https://github.com/octocat/Hello-World/compare/master...topic.diff',
+  html_url: 'https://github.com/octocat/Hello-World/commit/6dcb09b5b57875f334f61aebed695e2e4193db5e',
+  patch_url: 'https://github.com/octocat/Hello-World/compare/master...topic.patch',
+  permalink_url: 'https://github.com/octocat/Hello-World/compare/octocat:bbcd538c8e72b8c175046e27cc8f907076331401...octocat:0328041d1152db8ae77652d1618a02e57f745f17',
+
+  afterCreate(githubCompare, server) {
+    // manually setup related records
+    githubCompare.baseCommit =  server.create('github-commit');
+    githubCompare.mergeBaseCommit = server.create('github-commit');
+    githubCompare.commits = server.createList('github-commit', 3);
+    githubCompare.files = server.createList('github-file', 3);
+    githubCompare.save();
+  }
+});

--- a/tests/dummy/mirage/factories/github-file.js
+++ b/tests/dummy/mirage/factories/github-file.js
@@ -1,0 +1,18 @@
+import { Factory, faker } from 'ember-cli-mirage';
+
+export default Factory.extend({
+  id() {
+    return this.sha;
+  },
+  additions: faker.random.number(),
+  blob_url: 'https://github.com/octocat/Hello-World/blob/7ca483543807a51b6079e54ac4cc392bc29ae284/file1.txt',
+  changes: faker.random.number(),
+  deletions: faker.random.number(),
+  filename: 'file1.text',
+  patch: '@@ -29,7 +29,7 @@\n.....',
+  raw_url: 'https://github.com/octocat/Hello-World/raw/7ca483543807a51b6079e54ac4cc392bc29ae284/file1.txt',
+  sha: function(i) {
+    return `51a87a3027a3ab2asfsfb23dd24186dfd7d587${i}`
+  },
+  status: 'modified'
+});

--- a/tests/dummy/mirage/models/github-commit.js
+++ b/tests/dummy/mirage/models/github-commit.js
@@ -1,0 +1,4 @@
+import { Model } from 'ember-cli-mirage';
+
+export default Model.extend({
+});

--- a/tests/dummy/mirage/models/github-compare.js
+++ b/tests/dummy/mirage/models/github-compare.js
@@ -1,0 +1,8 @@
+import { Model, hasMany, belongsTo } from 'ember-cli-mirage';
+
+export default Model.extend({
+  baseCommit: belongsTo('github-commit'),
+  mergeBaseCommit: belongsTo('github-commit'),
+  commits: hasMany('github-commit'),
+  files: hasMany('github-file')
+});

--- a/tests/dummy/mirage/models/github-file.js
+++ b/tests/dummy/mirage/models/github-file.js
@@ -1,0 +1,4 @@
+import { Model } from 'ember-cli-mirage';
+
+export default Model.extend({
+});

--- a/tests/dummy/mirage/serializers/github-compare.js
+++ b/tests/dummy/mirage/serializers/github-compare.js
@@ -1,0 +1,10 @@
+import ApplicationSerializer from './application';
+import { underscore } from '@ember/string';
+
+export default ApplicationSerializer.extend({
+  include: ['mergeBaseCommit', 'baseCommit', 'files', 'commits'],
+
+  keyForEmbeddedRelationship(attributeName) {
+    return underscore(attributeName)
+  }
+});

--- a/tests/helpers/custom-helpers/assert-github-compare-ok.js
+++ b/tests/helpers/custom-helpers/assert-github-compare-ok.js
@@ -1,0 +1,24 @@
+import { registerHelper } from '@ember/test';
+import QUnit from 'qunit';
+import assertionBuilder from '../utils/defined-attribute-assertion-builder';
+
+QUnit.assert.githubCompareOk = assertionBuilder([
+  'id',
+  'aheadBy',
+  'behindBy',
+  'status',
+  'totalCommits',
+  'diffUrl',
+  'htmlUrl',
+  'patchUrl',
+  'permalinkUrl',
+  'baseCommit',
+  'mergeBaseCommit'
+]);
+
+export default registerHelper(
+  'githubCompareOk',
+  function (app, assert, compare) {
+    assert.githubCompareOk(compare);
+  }
+);

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -12,6 +12,7 @@ import './custom-helpers/assert-github-blob-ok';
 import './custom-helpers/assert-github-tree-ok';
 import './custom-helpers/assert-github-pull-ok';
 import './custom-helpers/assert-github-member-ok';
+import './custom-helpers/assert-github-compare-ok';
 
 export default function startApp(attrs) {
   let attributes = merge({}, config.APP);

--- a/tests/unit/adapters/github-compare-test.js
+++ b/tests/unit/adapters/github-compare-test.js
@@ -1,0 +1,18 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('adapter:github-compare', 'Unit | Adapter | github compare', {
+  needs: ['service:github-session']
+});
+
+test('it builds the URL for a specific comparison query correctly', function(assert) {
+  let adapter = this.subject();
+  const host = adapter.get('host');
+  const repo = 'jimmay5469/old-hash';
+  const base = 1234
+  const head = 5678;
+
+  assert.equal(
+    adapter.buildURL('github-compare', null, null, 'queryRecord', { repo, base, head }),
+    `${host}/repos/${repo}/compare/${base}...${head}`
+  );
+});

--- a/tests/unit/models/github-commit-test.js
+++ b/tests/unit/models/github-commit-test.js
@@ -1,0 +1,12 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('github-commit', 'Unit | Model | github commit', {
+  // Specify the other units that are required for this test.
+  needs: []
+});
+
+test('it exists', function(assert) {
+  let model = this.subject();
+  // let store = this.store();
+  assert.ok(!!model);
+});

--- a/tests/unit/models/github-compare-test.js
+++ b/tests/unit/models/github-compare-test.js
@@ -1,0 +1,12 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('github-compare', 'Unit | Model | github compare', {
+  // Specify the other units that are required for this test.
+  needs: []
+});
+
+test('it exists', function(assert) {
+  let model = this.subject();
+  // let store = this.store();
+  assert.ok(!!model);
+});

--- a/tests/unit/models/github-file-test.js
+++ b/tests/unit/models/github-file-test.js
@@ -1,0 +1,12 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('github-file', 'Unit | Model | github file', {
+  // Specify the other units that are required for this test.
+  needs: []
+});
+
+test('it exists', function(assert) {
+  let model = this.subject();
+  // let store = this.store();
+  assert.ok(!!model);
+});

--- a/tests/unit/serializers/github-compare-test.js
+++ b/tests/unit/serializers/github-compare-test.js
@@ -1,0 +1,14 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('github-compare', 'Unit | Serializer | github compare', {
+  needs: ['serializer:github-compare', 'model:github-commit', 'model:github-file']
+});
+
+// Replace this with your real tests.
+test('it serializes records', function(assert) {
+  let record = this.subject();
+
+  let serializedRecord = record.serialize();
+
+  assert.ok(serializedRecord);
+});


### PR DESCRIPTION
Adds the ability to compare two commits: 

`this.get('store').queryRecord('github-compare', { repo: 'jimmay5469/old-hash', base: '1234', head: '5678' });`

 [API docs](https://developer.github.com/v3/repos/commits/#compare-two-commits)