### PR TITLE
properly deprecate removed properties

### DIFF
--- a/addon/models/github-organization.js
+++ b/addon/models/github-organization.js
@@ -1,12 +1,23 @@
 import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
 import { hasMany } from 'ember-data/relationships';
+import { deprecate } from '@ember/application/deprecations';
+import { computed } from '@ember/object';
 
 export default Model.extend({
   login: attr('string'),
   name: attr('string'),
   avatarUrl: attr('string'),
 
-  members: hasMany('github-member', { inverse: null }),
-  repositories: hasMany('github-repository')
+  members: hasMany('github-member'),
+  repositories: hasMany('github-repository'),
+
+  githubUsers: computed('members.[]', function() {
+    deprecate('The githubUsers property on the github-organization model has been deprecated.  Please use the members property.', false, { id: 'ember-data-github.deprecated-model-props', until: '1.0.0' });
+    return this.get('members');
+  }),
+  githubRepositories: computed('repositories.[]', function() {
+    deprecate('The githubRepositories property on the github-organization model has been deprecated.  Please use the repositories property.', false, { id: 'ember-data-github.deprecated-model-props', until: '1.0.0' });
+    return this.get('repositories');
+  })
 });

--- a/addon/models/github-release.js
+++ b/addon/models/github-release.js
@@ -21,8 +21,8 @@ export default Model.extend({
   publishedAt: attr('date'),
 
   author: belongsTo('github-user', { inverse: null }),
-  user: computed(function() {
-    deprecate('The user property on the github-release model has been deprecated.  Please use the author property.', false, { id: 'ember-data-github.release-author', until: '1.0.0' });
+  user: computed('author', function() {
+    deprecate('The user property on the github-release model has been deprecated.  Please use the author property.', false, { id: 'ember-data-github.deprecated-model-props', until: '1.0.0' });
     return this.get('author');
   }),
   repository: belongsTo('github-repository')

--- a/addon/models/github-user.js
+++ b/addon/models/github-user.js
@@ -1,6 +1,8 @@
 import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
 import { hasMany } from 'ember-data/relationships';
+import { deprecate } from '@ember/application/deprecations';
+import { computed } from '@ember/object';
 
 export default Model.extend({
   login: attr('string'),
@@ -21,5 +23,10 @@ export default Model.extend({
   email: attr('string'),
   bio: attr('string'),
 
-  repositories: hasMany('github-repository')
+  repositories: hasMany('github-repository'),
+
+  githubRepositories: computed('repositories.[]', function() {
+    deprecate('The githubRepositories property on the github-user model has been deprecated.  Please use the repositories property.', false, { id: 'ember-data-github.deprecated-model-props', until: '1.0.0' });
+    return this.get('repositories');
+  }),
 });

--- a/tests/unit/serializers/github-release-test.js
+++ b/tests/unit/serializers/github-release-test.js
@@ -2,7 +2,7 @@ import { moduleForModel, test } from 'ember-qunit';
 
 moduleForModel('github-release', 'Unit | Serializer | github release', {
   // Specify the other units that are required for this test.
-  needs: ['serializer:github-release', 'model:github-user']
+  needs: ['serializer:github-release', 'model:github-user', 'model:github-repository']
 });
 
 // Replace this with your real tests.


### PR DESCRIPTION
More cleanly deprecates properties renamed in https://github.com/elwayman02/ember-data-github/pull/131/ so that we can remove them in the future