### PR TITLE
use embeddedrecord to pull user out of payloads

### DIFF
--- a/addon/serializers/github-pull.js
+++ b/addon/serializers/github-pull.js
@@ -1,12 +1,17 @@
 import GithubSerializer from 'ember-data-github/serializers/github';
+import DS from 'ember-data';
 
-export default GithubSerializer.extend({
+const { EmbeddedRecordsMixin } = DS;
+
+export default GithubSerializer.extend(EmbeddedRecordsMixin, {
+  attrs: {
+    user: { embedded: 'always' }
+  },
+
   normalize(modelClass, resourceHash, prop) {
     resourceHash.user_avatar_url = resourceHash.user.avatar_url;
-    resourceHash.user_login = resourceHash.user.login,
-    resourceHash.links =  {
-      user: resourceHash.user.url
-    };
+    resourceHash.user_login = resourceHash.user.login;
+
     return this._super(modelClass, resourceHash, prop);
   }
 });

--- a/addon/serializers/github-release.js
+++ b/addon/serializers/github-release.js
@@ -1,10 +1,10 @@
 import GithubSerializer from 'ember-data-github/serializers/github';
+import DS from 'ember-data';
 
-export default GithubSerializer.extend({
-  normalize(modelClass, resourceHash, prop) {
-    resourceHash.links = {
-      user: resourceHash.author.url
-    };
-    return this._super(modelClass, resourceHash, prop);
+const { EmbeddedRecordsMixin } = DS;
+
+export default GithubSerializer.extend(EmbeddedRecordsMixin, {
+  attrs: {
+    author: { embedded: 'always' }
   }
 });

--- a/addon/serializers/github-repository.js
+++ b/addon/serializers/github-repository.js
@@ -1,10 +1,16 @@
 import GithubSerializer from 'ember-data-github/serializers/github';
+import DS from 'ember-data';
 
-export default GithubSerializer.extend({
+const { EmbeddedRecordsMixin } = DS;
+
+export default GithubSerializer.extend(EmbeddedRecordsMixin, {
+  attrs: {
+    owner: { embedded: 'always' }
+  },
+
   normalize(modelClass, resourceHash, prop) {
     resourceHash.id = resourceHash.recordId || resourceHash.full_name,
     resourceHash.links = {
-      owner: resourceHash.owner.url,
       defaultBranch: `${resourceHash.url}/branches/${resourceHash.default_branch}`,
       branches: `${resourceHash.url}/branches`,
       pulls: `${resourceHash.url}/pulls`,

--- a/tests/acceptance/github-release-test.js
+++ b/tests/acceptance/github-release-test.js
@@ -70,7 +70,7 @@ test('getting a releases\' author', function (assert) {
       return release.get('author').then(function (user) {
         assert.githubUserOk(user);
         assert.equal(store.peekAll('githubUser').get('length'), 1, 'loads 1 user');
-        assert.equal(server.pretender.handledRequests.length, 2, 'handles 2 requests');
+        assert.equal(server.pretender.handledRequests.length, 1, 'handles 1 requests');
         assert.equal(server.pretender.handledRequests[0].requestHeaders.Authorization, 'token abc123', 'has the authorization token');
       });
     });

--- a/tests/acceptance/github-repository-test.js
+++ b/tests/acceptance/github-repository-test.js
@@ -83,7 +83,7 @@ test('getting a repository\'s owner', function (assert) {
     return store.findRecord('githubRepository', 'user0/repository0').then((repository) => {
       return repository.get('owner').then(function (owner) {
         assert.githubUserOk(owner);
-        assert.equal(server.pretender.handledRequests.length, 2, 'handles 2 requests');
+        assert.equal(server.pretender.handledRequests.length, 1, 'handles 1 request1');
         assert.equal(server.pretender.handledRequests[0].requestHeaders.Authorization, 'token abc123', 'has the authorization token');
       });
     });

--- a/tests/acceptance/gitub-pull-test.js
+++ b/tests/acceptance/gitub-pull-test.js
@@ -70,7 +70,7 @@ test('getting a pull request\'s author', function (assert) {
       return pull.get('user').then(function (user) {
         assert.githubUserOk(user);
         assert.equal(store.peekAll('githubUser').get('length'), 1, 'loads 1 user');
-        assert.equal(server.pretender.handledRequests.length, 2, 'handles 2 requests');
+        assert.equal(server.pretender.handledRequests.length, 1, 'handles 1 requests');
         assert.equal(server.pretender.handledRequests[0].requestHeaders.Authorization, 'token abc123', 'has the authorization token');
       });
     });


### PR DESCRIPTION
I'm not sure if/how this worked before, but since the user data is embedded in the payload we get from GitHub we can simply extract it out without needing to setup any links manually