### PR TITLE
add 0.7.0 to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v0.7.0 (2018-02-23)
+
+#### Enhancement
+* [#153](https://github.com/elwayman02/ember-data-github/pull/153) Retrieve Repo List By User. ([@elwayman02](https://github.com/elwayman02))
+
+#### Committers: 1
+- Jordan Hawker ([elwayman02](https://github.com/elwayman02))
+
 ## v0.6.0 (2018-02-14)
 
 #### Enhancement


### PR DESCRIPTION
@elwayman02 I was able to generate this by running:

> yarn run lerna-changelog --tag-from 0.6.0

I think `yarn run lerna-changelog` isn't working because it needs to be run _before_ the new release is made