### PR TITLE
lock ember-cli-mirage to 0.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "ember-cli-htmlbars": "^2.0.1",
     "ember-cli-htmlbars-inline-precompile": "^1.0.0",
     "ember-cli-inject-live-reload": "^1.4.1",
-    "ember-cli-mirage": "^0.4.1",
+    "ember-cli-mirage": "0.4.1",
     "ember-cli-qunit": "^4.1.1",
     "ember-cli-release": "1.0.0-beta.2",
     "ember-cli-sass": "^7.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2366,7 +2366,7 @@ ember-cli-lodash-subset@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/ember-cli-lodash-subset/-/ember-cli-lodash-subset-2.0.1.tgz#20cb68a790fe0fde2488ddfd8efbb7df6fe766f2"
 
-ember-cli-mirage@^0.4.1:
+ember-cli-mirage@0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/ember-cli-mirage/-/ember-cli-mirage-0.4.1.tgz#bfdfe61e5e74dc3881ed31f12112dae1a29f0d4c"
   dependencies:


### PR DESCRIPTION
something in 0.4.2 is causing tests to fail on master since travis installs with no `yarn.lock`