### PR TITLE
Fix `headers.link` not being parsed.

### DIFF
--- a/addon/adapters/github.js
+++ b/addon/adapters/github.js
@@ -34,7 +34,7 @@ export default RESTAdapter.extend({
   //   }
   //
   handleResponse(status, headers, payload, requestData) {
-    const linkHeader = headers.link;
+    const linkHeader = headers.link || headers.Link;
     const result = this._super(status, headers, payload, requestData);
     if (isNone(linkHeader)) {
       return result;

--- a/addon/adapters/github.js
+++ b/addon/adapters/github.js
@@ -34,7 +34,7 @@ export default RESTAdapter.extend({
   //   }
   //
   handleResponse(status, headers, payload, requestData) {
-    const linkHeader = headers.Link;
+    const linkHeader = headers.link;
     const result = this._super(status, headers, payload, requestData);
     if (isNone(linkHeader)) {
       return result;

--- a/tests/unit/adapters/github-test.js
+++ b/tests/unit/adapters/github-test.js
@@ -46,7 +46,7 @@ test('it extracts links from the Link header', function(assert) {
   let last = '<https://api.github.com/resouce?page=4&per_page=5>; rel="last"';
 
   let headers = {
-    Link: [first, next, prev, last].join(', ')
+    link: [first, next, prev, last].join(', ')
   };
 
   assert.deepEqual(adapter.handleResponse(200, headers, {}, null).links, {

--- a/tests/unit/adapters/github-test.js
+++ b/tests/unit/adapters/github-test.js
@@ -46,6 +46,25 @@ test('it extracts links from the Link header', function(assert) {
   let last = '<https://api.github.com/resouce?page=4&per_page=5>; rel="last"';
 
   let headers = {
+    Link: [first, next, prev, last].join(', ')
+  };
+
+  assert.deepEqual(adapter.handleResponse(200, headers, {}, null).links, {
+    first: 'https://api.github.com/resouce?page=1&per_page=5',
+    next: 'https://api.github.com/resouce?page=3&per_page=5',
+    prev: 'https://api.github.com/resouce?page=1&per_page=5',
+    last: 'https://api.github.com/resouce?page=4&per_page=5'
+  });
+});
+
+test('it extracts links from the link header', function(assert) {
+  let adapter = this.subject();
+  let first = '<https://api.github.com/resouce?page=1&per_page=5>; rel="first"';
+  let next = '<https://api.github.com/resouce?page=3&per_page=5>; rel="next"';
+  let prev = '<https://api.github.com/resouce?page=1&per_page=5>; rel="prev"';
+  let last = '<https://api.github.com/resouce?page=4&per_page=5>; rel="last"';
+
+  let headers = {
     link: [first, next, prev, last].join(', ')
   };
 


### PR DESCRIPTION
At some point `headers.Link` became `headers.link`

![image](https://user-images.githubusercontent.com/790999/46158610-d9f35380-c243-11e8-9286-04ace6eac109.png)

I'm assuming an upgrade of something down the line caused this change.