### PR TITLE
Add dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,14 @@
+version: 1
+update_configs:
+  # Keep package.json (& lockfiles) up to date as soon as
+  # new versions are published to the npm registry
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "weekly"
+    automerged_updates:
+      - match:
+          dependency_type: "all"
+          update_type: "all"
+    version_requirement_updates: "increase_versions"
+    commit_message:
+      prefix: "[skip netlify]"


### PR DESCRIPTION
@Dhaulagiri I saw you merging the old greenkeeper PRs today. Once you have a passing build in master again, we can merge this to enable dependabot for managing and auto-merging dependencies moving forward. Once that's in place, we can also set up a CD job with Netlify (or the service of your choice, if you want to own it) to automatically build and deploy the demo app for PRs (deploy previews) and changes to master.