### PR TITLE
Replace ember-cli-release with release-it

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,62 @@
+# Release
+
+Releases are mostly automated using
+[release-it](https://github.com/release-it/release-it/) and
+[lerna-changelog](https://github.com/lerna/lerna-changelog/).
+
+
+## Preparation
+
+Since the majority of the actual release process is automated, the primary
+remaining task prior to releasing is confirming that all pull requests that
+have been merged since the last release have been labeled with the appropriate
+`lerna-changelog` labels and the titles have been updated to ensure they
+represent something that would make sense to our users. Some great information
+on why this is important can be found at
+[keepachangelog.com](https://keepachangelog.com/en/1.0.0/), but the overall
+guiding principle here is that changelogs are for humans, not machines.
+
+When reviewing merged PR's the labels to be used are:
+
+* breaking - Used when the PR is considered a breaking change.
+* enhancement - Used when the PR adds a new feature or enhancement.
+* bug - Used when the PR fixes a bug included in a previous release.
+* documentation - Used when the PR adds or updates documentation.
+* internal - Used for internal changes that still require a mention in the
+  changelog/release notes.
+
+
+## Release
+
+Once the prep work is completed, the actual release is straight forward:
+
+* First, ensure that you have installed your projects dependencies:
+
+```
+yarn install
+```
+
+* Second, ensure that you have obtained a
+  [GitHub personal access token][generate-token] with the `repo` scope (no
+  other permissions are needed). Make sure the token is available as the
+  `GITHUB_AUTH` environment variable.
+
+  For instance:
+
+  ```bash
+  export GITHUB_AUTH=abc123def456
+  ```
+
+[generate-token]: https://github.com/settings/tokens/new?scopes=repo&description=GITHUB_AUTH+env+variable
+
+* And last (but not least 😁) do your release.
+
+```
+npx release-it
+```
+
+[release-it](https://github.com/release-it/release-it/) manages the actual
+release process. It will prompt you to to choose the version number after which
+you will have the chance to hand tweak the changelog to be used (for the
+`CHANGELOG.md` and GitHub release), then `release-it` continues on to tagging,
+pushing the tag and commits, etc.

--- a/config/release.js
+++ b/config/release.js
@@ -1,6 +1,0 @@
-/* jshint node:true */
-
-module.exports = {
-  manifest: ['package.json', 'bower.json'],
-  publish: true
-};

--- a/package.json
+++ b/package.json
@@ -8,19 +8,19 @@
     "github",
     "api"
   ],
+  "repository": "git@github.com:elwayman02/ember-data-github",
   "license": "MIT",
   "author": "Jordan Hawker <hawker.jordan@gmail.com> (http://www.JordanHawker.com)",
   "directories": {
     "doc": "doc",
     "test": "tests"
   },
-  "repository": "git@github.com:elwayman02/ember-data-github",
   "scripts": {
     "build": "ember build",
+    "changelog": "lerna-changelog",
     "lint:js": "eslint ./*.js addon addon-test-support app config lib server test-support tests mirage-support",
     "start": "ember serve",
     "test": "ember test",
-    "changelog": "lerna-changelog",
     "test:all": "ember try:each"
   },
   "dependencies": {
@@ -42,7 +42,6 @@
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-mirage": "^1.1.0",
     "ember-cli-qunit": "^4.1.1",
-    "ember-cli-release": "1.0.0-beta.2",
     "ember-cli-sass": "^7.1.4",
     "ember-cli-shims": "^1.2.0",
     "ember-cli-sri": "^2.1.0",
@@ -60,10 +59,15 @@
     "eslint-plugin-node": "^6.0.1",
     "faker": "^4.1.0",
     "lerna-changelog": "^0.8.2",
-    "loader.js": "^4.2.3"
+    "loader.js": "^4.2.3",
+    "release-it": "^13.6.5",
+    "release-it-lerna-changelog": "^2.3.0"
   },
   "engines": {
     "node": ">= 8.*"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org"
   },
   "changelog": {
     "repo": "elwayman02/ember-data-github",
@@ -80,5 +84,20 @@
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"
+  },
+  "release-it": {
+    "plugins": {
+      "release-it-lerna-changelog": {
+        "infile": "CHANGELOG.md",
+        "launchEditor": false
+      }
+    },
+    "git": {
+      "tagName": "v${version}"
+    },
+    "github": {
+      "release": true,
+      "tokenRef": "GITHUB_AUTH"
+    }
   }
 }


### PR DESCRIPTION
The new release-it config includes an integration with lerna-changelog to seamlessly integrate together without using the deprecated addon. You will need a local GITHUB_AUTH token as noted in the new RELEASE.md.

This onboard was handled by `create-rwjblue-release-it-setup`: https://github.com/rwjblue/create-rwjblue-release-it-setup